### PR TITLE
Allow the lexer to return the original string

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -65,6 +65,13 @@ abstract class AbstractLexer
     public $token;
 
     /**
+     * The current input string.
+     *
+     * @var string
+     */
+    protected $input;
+
+    /**
      * Sets the input data to be tokenized.
      *
      * The Lexer is immediately reset and the new input tokenized.
@@ -78,6 +85,7 @@ abstract class AbstractLexer
     {
         $this->tokens = array();
         $this->reset();
+        $this->input = $input;
         $this->scan($input);
     }
 
@@ -265,6 +273,16 @@ abstract class AbstractLexer
         }
 
         return $token;
+    }
+
+    /**
+     * Get the original string read so far.
+     *
+     * @return string
+     */
+    public function getOriginalUntilNow()
+    {
+        return substr($this->input, 0, $this->lookahead['position']);
     }
 
     /**


### PR DESCRIPTION
Together with https://github.com/doctrine/annotations/pull/14 allows for better annotation error reporting.

We need to store the input string because the preg_split throws away the patterns from `getNonCatchablePatterns()` including line breaks.
