### PR TITLE
Add a way to override modifiers

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -247,8 +247,12 @@ abstract class AbstractLexer
         static $regex;
 
         if ( ! isset($regex)) {
-            $regex = '/(' . implode(')|(', $this->getCatchablePatterns()) . ')|'
-                   . implode('|', $this->getNonCatchablePatterns()) . '/i';
+            $regex = sprintf(
+                '/(%s)|%s/%s',
+                implode(')|(', $this->getCatchablePatterns()),
+                implode('|', $this->getNonCatchablePatterns()),
+                $this->getModifiers()
+            );
         }
 
         $flags = PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE;
@@ -286,6 +290,16 @@ abstract class AbstractLexer
         }
 
         return $token;
+    }
+
+    /**
+     * Regex modifiers
+     *
+     * @return string
+     */
+    protected function getModifiers()
+    {
+        return 'i';
     }
 
     /**


### PR DESCRIPTION
I'm currently experiencing an issue with UTF-8 characters.
I'd like to change modifiers (currently "i") to add a new one ("u" in my case).
