### PR TITLE
Fix PSR-2 errors.

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -132,7 +132,7 @@ abstract class AbstractLexer
     }
 
     /**
-     * Retrieve the original lexer's input until a given position. 
+     * Retrieve the original lexer's input until a given position.
      *
      * @param integer $position
      *
@@ -246,7 +246,7 @@ abstract class AbstractLexer
     {
         static $regex;
 
-        if ( ! isset($regex)) {
+        if (!isset($regex)) {
             $regex = sprintf(
                 '/(%s)|%s/%s',
                 implode(')|(', $this->getCatchablePatterns()),


### PR DESCRIPTION
```
phpcs --standard=PSR2 ./vendor/doctrine/lexer/lib/Doctrine/Common/Lexer/AbstractLexer.php

FILE: <...>/vendor/doctrine/lexer/lib/Doctrine/Common/Lexer/AbstractLexer.php
------------------------------------------------------------------------------------------
FOUND 2 ERRORS AFFECTING 2 LINES
------------------------------------------------------------------------------------------
 135 | ERROR | [x] Whitespace found at end of line
 249 | ERROR | [x] Expected 0 spaces after opening bracket; 1 found
------------------------------------------------------------------------------------------
PHPCBF CAN FIX THE 2 MARKED SNIFF VIOLATIONS AUTOMATICALLY
------------------------------------------------------------------------------------------

Time: 148ms; Memory: 6Mb
```