### PR TITLE
Add token index

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,14 @@
     "require": {
         "php": ">=5.3.2"
     },
+    "require-dev": {
+        "phpunit/phpunit": "^4.5"
+    },
     "autoload": {
         "psr-4": { "Doctrine\\Common\\Lexer\\": "lib/Doctrine/Common/Lexer" }
+    },
+    "autoload-dev": {
+        "psr-4": { "Doctrine\\Tests\\": "tests/Doctrine" }
     },
     "extra": {
         "branch-alias": {

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -40,6 +40,7 @@ abstract class AbstractLexer
      * Array of scanned tokens.
      *
      * Each token is an associative array containing three items:
+     *  - 'index'    : the token index in the input string
      *  - 'value'    : the string value of the token in the input string
      *  - 'type'     : the type of the token (identifier, numeric, string, input
      *                 parameter, none)
@@ -258,15 +259,18 @@ abstract class AbstractLexer
         $flags = PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE;
         $matches = preg_split($regex, $input, -1, $flags);
 
+        $index = 0;
         foreach ($matches as $match) {
             // Must remain before 'value' assignment since it can change content
             $type = $this->getType($match[0]);
 
-            $this->tokens[] = array(
+            $this->tokens[$index] = array(
+                'index' => $index,
                 'value' => $match[0],
                 'type'  => $type,
                 'position' => $match[1],
             );
+            $index++;
         }
     }
 

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -1,0 +1,175 @@
+<?php
+
+namespace Doctrine\Tests\Common\Lexer;
+
+class AbstractLexerTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * @var ConcreteLexer
+     */
+    private $concreteLexer;
+
+    public function setUp()
+    {
+        $this->concreteLexer = new ConcreteLexer();
+    }
+
+    public function dataProvider()
+    {
+        return array(
+            array(
+                'price=10',
+                array(
+                    array(
+                        'index' => 0,
+                        'value' => 'price',
+                        'type' => 'string',
+                        'position' => 0,
+                    ),
+                    array(
+                        'index' => 1,
+                        'value' => '=',
+                        'type' => 'operator',
+                        'position' => 5,
+                    ),
+                    array(
+                        'index' => 2,
+                        'value' => 10,
+                        'type' => 'int',
+                        'position' => 6,
+                    ),
+                ),
+            ),
+        );
+    }
+
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $input
+     * @param $expectedTokens
+     */
+    public function testMoveNext($input, $expectedTokens)
+    {
+        $this->concreteLexer->setInput($input);
+        $this->assertNull($this->concreteLexer->lookahead);
+
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteLexer->moveNext());
+            $this->assertEquals($expectedTokens[$i], $this->concreteLexer->lookahead);
+        }
+
+        $this->assertFalse($this->concreteLexer->moveNext());
+        $this->assertNull($this->concreteLexer->lookahead);
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $input
+     * @param $expectedTokens
+     */
+    public function testPeek($input, $expectedTokens)
+    {
+        $this->concreteLexer->setInput($input);
+        foreach ($expectedTokens as $expectedToken) {
+            $this->assertEquals($expectedToken, $this->concreteLexer->peek());
+        }
+
+        $this->assertNull($this->concreteLexer->peek());
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $input
+     * @param $expectedTokens
+     */
+    public function testGlimpse($input, $expectedTokens)
+    {
+        $this->concreteLexer->setInput($input);
+
+        foreach ($expectedTokens as $expectedToken) {
+            $this->assertEquals($expectedToken, $this->concreteLexer->glimpse());
+            $this->concreteLexer->moveNext();
+        }
+
+        $this->assertNull($this->concreteLexer->peek());
+    }
+
+    public function inputUntilPositionDataProvider()
+    {
+        return array(
+            array('price=10', 5, 'price'),
+        );
+    }
+
+    /**
+     * @dataProvider inputUntilPositionDataProvider
+     *
+     * @param $input
+     * @param $position
+     * @param $expectedInput
+     */
+    public function testGetInputUntilPosition($input, $position, $expectedInput)
+    {
+        $this->concreteLexer->setInput($input);
+
+        $this->assertSame($expectedInput, $this->concreteLexer->getInputUntilPosition($position));
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $input
+     * @param $expectedTokens
+     */
+    public function testIsNextToken($input, $expectedTokens)
+    {
+        $this->concreteLexer->setInput($input);
+
+        $this->concreteLexer->moveNext();
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteLexer->isNextToken($expectedTokens[$i]['type']));
+            $this->concreteLexer->moveNext();
+        }
+    }
+
+    /**
+     * @dataProvider dataProvider
+     *
+     * @param $input
+     * @param $expectedTokens
+     */
+    public function testIsNextTokenAny($input, $expectedTokens)
+    {
+        $allTokenTypes = array_map(function ($token) {
+            return $token['type'];
+        }, $expectedTokens);
+
+        $this->concreteLexer->setInput($input);
+
+        $this->concreteLexer->moveNext();
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteLexer->isNextTokenAny(array($expectedTokens[$i]['type'])));
+            $this->assertTrue($this->concreteLexer->isNextTokenAny($allTokenTypes));
+            $this->concreteLexer->moveNext();
+        }
+    }
+
+    public function testGetLiteral()
+    {
+        $this->assertSame('Doctrine\Tests\Common\Lexer\ConcreteLexer::INT', $this->concreteLexer->getLiteral('int'));
+    }
+
+    public function testIsA()
+    {
+        $this->assertTrue($this->concreteLexer->isA(11, 'int'));
+        $this->assertTrue($this->concreteLexer->isA(1.1, 'int'));
+        $this->assertTrue($this->concreteLexer->isA('=', 'operator'));
+        $this->assertTrue($this->concreteLexer->isA('>', 'operator'));
+        $this->assertTrue($this->concreteLexer->isA('<', 'operator'));
+        $this->assertTrue($this->concreteLexer->isA('fake_text', 'string'));
+    }
+}

--- a/tests/Doctrine/Common/Lexer/ConcreteLexer.php
+++ b/tests/Doctrine/Common/Lexer/ConcreteLexer.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+class ConcreteLexer extends AbstractLexer
+{
+    const INT = 'int';
+
+    protected function getCatchablePatterns()
+    {
+        return array(
+            '=|<|>',
+            '[a-z]+',
+            '\d+',
+        );
+    }
+
+    protected function getNonCatchablePatterns()
+    {
+        return array(
+            '\s+',
+            '(.)',
+        );
+    }
+
+    protected function getType(&$value)
+    {
+        if (is_numeric($value)) {
+            $value = (int)$value;
+
+            return 'int';
+        }
+        if (in_array($value, array('=', '<', '>'))) {
+            return 'operator';
+        }
+        if (is_string($value)) {
+            return 'string';
+        }
+
+        return;
+    }
+}


### PR DESCRIPTION
Hi, i recently work on new project [Xpression](https://github.com/Symftony/Xpression)

My need is to `resetPosition` at token index but the `$token['position']` was the string position of this token in the input string.

My actual workaround was to keep the lexerI index in my [Parser code](https://github.com/Symftony/Xpression/blob/master/src/Parser.php#L90) and reset it each time i need it.

So i think if the token index was store in the token i can get it easily with `$token['index']`

Thank to read.