### PR TITLE
Extract static variable $regex into property

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -68,6 +68,13 @@ abstract class AbstractLexer
     public $token;
 
     /**
+     * Composed regex for input parsing.
+     *
+     * @var string
+     */
+    private $regex;
+
+    /**
      * Sets the input data to be tokenized.
      *
      * The Lexer is immediately reset and the new input tokenized.
@@ -235,10 +242,8 @@ abstract class AbstractLexer
      */
     protected function scan($input)
     {
-        static $regex;
-
-        if (! isset($regex)) {
-            $regex = sprintf(
+        if (! isset($this->regex)) {
+            $this->regex = sprintf(
                 '/(%s)|%s/%s',
                 implode(')|(', $this->getCatchablePatterns()),
                 implode('|', $this->getNonCatchablePatterns()),
@@ -247,7 +252,7 @@ abstract class AbstractLexer
         }
 
         $flags   = PREG_SPLIT_NO_EMPTY | PREG_SPLIT_DELIM_CAPTURE | PREG_SPLIT_OFFSET_CAPTURE;
-        $matches = preg_split($regex, $input, -1, $flags);
+        $matches = preg_split($this->regex, $input, -1, $flags);
 
         if ($matches === false) {
             // Work around https://bugs.php.net/78122

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -269,4 +269,21 @@ class AbstractLexerTest extends TestCase
         $this->assertTrue($this->concreteLexer->isA('<', 'operator'));
         $this->assertTrue($this->concreteLexer->isA('fake_text', 'string'));
     }
+
+    public function testAddCatchablePatternsToMutableLexer()
+    {
+        $mutableLexer = new MutableLexer();
+        $mutableLexer->addCatchablePattern('[a-z]');
+        $mutableLexer->setInput('one');
+        $token = $mutableLexer->glimpse();
+
+        $this->assertEquals('o', $token['value']);
+
+        $mutableLexer = new MutableLexer();
+        $mutableLexer->addCatchablePattern('[a-z]+');
+        $mutableLexer->setInput('one');
+        $token = $mutableLexer->glimpse();
+
+        $this->assertEquals('one', $token['value']);
+    }
 }

--- a/tests/Doctrine/Common/Lexer/MutableLexer.php
+++ b/tests/Doctrine/Common/Lexer/MutableLexer.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+class MutableLexer extends AbstractLexer
+{
+    /** @var string[] */
+    private $catchablePatterns = [];
+
+    public function addCatchablePattern($pattern)
+    {
+        $this->catchablePatterns[] = $pattern;
+    }
+
+    protected function getCatchablePatterns()
+    {
+        return $this->catchablePatterns;
+    }
+
+    protected function getNonCatchablePatterns()
+    {
+        return ['[\s,]+'];
+    }
+
+    protected function getType(&$value)
+    {
+        return 1;
+    }
+}


### PR DESCRIPTION
Method `\Doctrine\Common\Lexer\AbstractLexer::scan` contains static variable `$regex`, which shares state between class instances. Consider following example, in which second instance (`$lexer2`) has different catchable pattern (`[a-z]+`), but still behaves like the first one:

```
class Lexer extends \Doctrine\Common\Lexer\AbstractLexer
{
    private $catchablePatterns = [];

    public function addCatchablePattern($pattern)
    {
        $this->catchablePatterns[] = $pattern;
    }

    protected function getCatchablePatterns()
    {
        return $this->catchablePatterns;
    }

    protected function getNonCatchablePatterns()
    {
        return ['[\s,]+'];
    }

    protected function getType(&$value)
    {
        return 1;
    }
}

$lexer1 = new Lexer();
$lexer1->addCatchablePattern('[a-z]');
$lexer1->setInput('one');
$token = $lexer1->glimpse();
var_dump($token['value']);
// string(1) "o"

$lexer2 = new Lexer();
$lexer2->addCatchablePattern('[a-z]+');
$lexer2->setInput('one');
$token = $lexer2->glimpse();
var_dump($token['value']);
// string(1) "o"
```