### PR TITLE
Allow the installation on PHP 7.1

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -13,3 +13,5 @@ jobs:
   phpunit:
     name: "PHPUnit"
     uses: "doctrine/.github/.github/workflows/continuous-integration.yml@1.4.1"
+    with:
+      php-versions: '["7.1", "7.2", "7.3", "7.4", "8.0", "8.1"]'

--- a/composer.json
+++ b/composer.json
@@ -17,12 +17,12 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.2 || ^8.0"
+        "php": "^7.1 || ^8.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
         "phpstan/phpstan": "1.3",
-        "phpunit/phpunit": "^8.2 || ^9.4",
+        "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "vimeo/psalm": "^4.11"
     },
     "autoload": {

--- a/phpcs.xml.dist
+++ b/phpcs.xml.dist
@@ -6,7 +6,7 @@
     <arg name="cache" value=".phpcs-cache"/>
     <arg name="colors" />
 
-    <config name="php_version" value="70200"/>
+    <config name="php_version" value="70100"/>
 
     <!-- Ignore warnings and show progress of the run -->
     <arg value="np"/>


### PR DESCRIPTION
Unless I missed something while skimming the code, this library does not use any features that aren't available on PHP 7.1 already. Lowering the minimum PHP version would in turn allow us to bump the minimal version of `doctrine/lexer` in the ORM.