### PR TITLE
Allow upgrading PHPStan again

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "doctrine/coding-standard": "^9.0",
-        "phpstan/phpstan": "1.3",
+        "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
         "vimeo/psalm": "^4.11"
     },


### PR DESCRIPTION
In #59, I by mistake removed the `^` from PHPStan's version constraint. I think, we don't want to update PHPStan manually here.