### PR TITLE
[TASK] Use proper docblock type for `AbstractLexer::isNextTokenAny()`

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -160,7 +160,7 @@ abstract class AbstractLexer
     /**
      * Checks whether any of the given tokens matches the current lookahead.
      *
-     * @param string[] $tokens
+     * @param list<int|string> $tokens
      *
      * @return bool
      */
@@ -187,7 +187,7 @@ abstract class AbstractLexer
     /**
      * Tells the lexer to skip input tokens until it sees a token with the given value.
      *
-     * @param string $type The token type to skip until.
+     * @param int|string $type The token type to skip until.
      *
      * @return void
      */

--- a/tests/Doctrine/Common/Lexer/AbstractIntTokenLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractIntTokenLexerTest.php
@@ -1,0 +1,281 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use PHPUnit\Framework\TestCase;
+
+use function array_map;
+use function count;
+use function setlocale;
+
+use const LC_ALL;
+
+class AbstractIntTokenLexerTest extends TestCase
+{
+    /** @var ConcreteIntTokenLexer */
+    private $concreteIntTokenLexer;
+
+    public function setUp(): void
+    {
+        $this->concreteIntTokenLexer = new ConcreteIntTokenLexer();
+    }
+
+    public function tearDown(): void
+    {
+        setlocale(LC_ALL, null);
+    }
+
+    /**
+     * @psalm-return list<array{string, list<array{value: string|int, type: int, position: int}>}>
+     */
+    public function dataProvider(): array
+    {
+        return [
+            [
+                'price=10',
+                [
+                    [
+                        'value' => 'price',
+                        'type' => ConcreteIntTokenLexer::T_STRING,
+                        'position' => 0,
+                    ],
+                    [
+                        'value' => '=',
+                        'type' => ConcreteIntTokenLexer::T_OPERATOR,
+                        'position' => 5,
+                    ],
+                    [
+                        'value' => 10,
+                        'type' => ConcreteIntTokenLexer::T_INT,
+                        'position' => 6,
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testResetPeek(): void
+    {
+        $expectedTokens = [
+            [
+                'value' => 'price',
+                'type' => ConcreteIntTokenLexer::T_STRING,
+                'position' => 0,
+            ],
+            [
+                'value' => '=',
+                'type' => ConcreteIntTokenLexer::T_OPERATOR,
+                'position' => 5,
+            ],
+            [
+                'value' => 10,
+                'type' => ConcreteIntTokenLexer::T_INT,
+                'position' => 6,
+            ],
+        ];
+
+        $this->concreteIntTokenLexer->setInput('price=10');
+
+        $this->assertEquals($expectedTokens[0], $this->concreteIntTokenLexer->peek());
+        $this->assertEquals($expectedTokens[1], $this->concreteIntTokenLexer->peek());
+        $this->concreteIntTokenLexer->resetPeek();
+        $this->assertEquals($expectedTokens[0], $this->concreteIntTokenLexer->peek());
+    }
+
+    public function testResetPosition(): void
+    {
+        $expectedTokens = [
+            [
+                'value' => 'price',
+                'type' => ConcreteIntTokenLexer::T_STRING,
+                'position' => 0,
+            ],
+            [
+                'value' => '=',
+                'type' => ConcreteIntTokenLexer::T_OPERATOR,
+                'position' => 5,
+            ],
+            [
+                'value' => 10,
+                'type' => ConcreteIntTokenLexer::T_INT,
+                'position' => 6,
+            ],
+        ];
+
+        $this->concreteIntTokenLexer->setInput('price=10');
+        $this->assertNull($this->concreteIntTokenLexer->lookahead);
+
+        $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+        $this->assertEquals($expectedTokens[0], $this->concreteIntTokenLexer->lookahead);
+
+        $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+        $this->assertEquals($expectedTokens[1], $this->concreteIntTokenLexer->lookahead);
+
+        $this->concreteIntTokenLexer->resetPosition(0);
+
+        $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+        $this->assertEquals($expectedTokens[0], $this->concreteIntTokenLexer->lookahead);
+    }
+
+    /**
+     * @psalm-param list<array{value: string|int, type: string, position: int}>  $expectedTokens
+     *
+     * @dataProvider dataProvider
+     */
+    public function testMoveNext(string $input, array $expectedTokens): void
+    {
+        $this->concreteIntTokenLexer->setInput($input);
+        $this->assertNull($this->concreteIntTokenLexer->lookahead);
+
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+            $this->assertEquals($expectedTokens[$i], $this->concreteIntTokenLexer->lookahead);
+        }
+
+        $this->assertFalse($this->concreteIntTokenLexer->moveNext());
+        $this->assertNull($this->concreteIntTokenLexer->lookahead);
+    }
+
+    public function testSkipUntil(): void
+    {
+        $this->concreteIntTokenLexer->setInput('price=10');
+
+        $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+        $this->concreteIntTokenLexer->skipUntil(ConcreteIntTokenLexer::T_OPERATOR);
+
+        $this->assertEquals(
+            [
+                'value' => '=',
+                'type' => ConcreteIntTokenLexer::T_OPERATOR,
+                'position' => 5,
+            ],
+            $this->concreteIntTokenLexer->lookahead
+        );
+    }
+
+    public function testUtf8Mismatch(): void
+    {
+        $this->concreteIntTokenLexer->setInput("\xE9=10");
+
+        $this->assertTrue($this->concreteIntTokenLexer->moveNext());
+
+        $this->assertEquals(
+            [
+                'value' => "\xE9=10",
+                'type' => ConcreteIntTokenLexer::T_STRING,
+                'position' => 0,
+            ],
+            $this->concreteIntTokenLexer->lookahead
+        );
+    }
+
+    /**
+     * @psalm-param list<array{value: string|int, type: string, position: int}> $expectedTokens
+     *
+     * @dataProvider dataProvider
+     */
+    public function testPeek(string $input, array $expectedTokens): void
+    {
+        $this->concreteIntTokenLexer->setInput($input);
+        foreach ($expectedTokens as $expectedToken) {
+            $this->assertEquals($expectedToken, $this->concreteIntTokenLexer->peek());
+        }
+
+        $this->assertNull($this->concreteIntTokenLexer->peek());
+    }
+
+    /**
+     * @psalm-param list<array{value: string|int, type: string, position: int}> $expectedTokens
+     *
+     * @dataProvider dataProvider
+     */
+    public function testGlimpse(string $input, array $expectedTokens): void
+    {
+        $this->concreteIntTokenLexer->setInput($input);
+
+        foreach ($expectedTokens as $expectedToken) {
+            $this->assertEquals($expectedToken, $this->concreteIntTokenLexer->glimpse());
+            $this->concreteIntTokenLexer->moveNext();
+        }
+
+        $this->assertNull($this->concreteIntTokenLexer->peek());
+    }
+
+    /**
+     * @psalm-return list<array{string, int, string}>
+     */
+    public function inputUntilPositionDataProvider(): array
+    {
+        return [
+            ['price=10', 5, 'price'],
+        ];
+    }
+
+    /**
+     * @dataProvider inputUntilPositionDataProvider
+     */
+    public function testGetInputUntilPosition(
+        string $input,
+        int $position,
+        string $expectedInput
+    ): void {
+        $this->concreteIntTokenLexer->setInput($input);
+
+        $this->assertSame($expectedInput, $this->concreteIntTokenLexer->getInputUntilPosition($position));
+    }
+
+    /**
+     * @psalm-param list<array{value: string|int, type: string, position: int}> $expectedTokens
+     *
+     * @dataProvider dataProvider
+     */
+    public function testIsNextToken(string $input, array $expectedTokens): void
+    {
+        $this->concreteIntTokenLexer->setInput($input);
+
+        $this->concreteIntTokenLexer->moveNext();
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteIntTokenLexer->isNextToken($expectedTokens[$i]['type']));
+            $this->concreteIntTokenLexer->moveNext();
+        }
+    }
+
+    /**
+     * @psalm-param list<array{value: string|int, type: string, position: int}> $expectedTokens
+     *
+     * @dataProvider dataProvider
+     */
+    public function testIsNextTokenAny(string $input, array $expectedTokens): void
+    {
+        $allTokenTypes = array_map(static function ($token) {
+            return $token['type'];
+        }, $expectedTokens);
+
+        $this->concreteIntTokenLexer->setInput($input);
+
+        $this->concreteIntTokenLexer->moveNext();
+        for ($i = 0; $i < count($expectedTokens); $i++) {
+            $this->assertTrue($this->concreteIntTokenLexer->isNextTokenAny([$expectedTokens[$i]['type']]));
+            $this->assertTrue($this->concreteIntTokenLexer->isNextTokenAny($allTokenTypes));
+            $this->concreteIntTokenLexer->moveNext();
+        }
+    }
+
+    public function testGetLiteral(): void
+    {
+        $this->assertSame('Doctrine\Tests\Common\Lexer\ConcreteIntTokenLexer::T_INT', $this->concreteIntTokenLexer->getLiteral(ConcreteIntTokenLexer::T_INT));
+        $this->assertSame('fake_token', $this->concreteIntTokenLexer->getLiteral('fake_token'));
+    }
+
+    public function testIsA(): void
+    {
+        $this->assertTrue($this->concreteIntTokenLexer->isA(11, ConcreteIntTokenLexer::T_INT));
+        $this->assertTrue($this->concreteIntTokenLexer->isA(1.1, ConcreteIntTokenLexer::T_INT));
+        $this->assertTrue($this->concreteIntTokenLexer->isA('=', ConcreteIntTokenLexer::T_OPERATOR));
+        $this->assertTrue($this->concreteIntTokenLexer->isA('>', ConcreteIntTokenLexer::T_OPERATOR));
+        $this->assertTrue($this->concreteIntTokenLexer->isA('<', ConcreteIntTokenLexer::T_OPERATOR));
+        $this->assertTrue($this->concreteIntTokenLexer->isA('fake_text', ConcreteIntTokenLexer::T_STRING));
+    }
+}

--- a/tests/Doctrine/Common/Lexer/ConcreteIntTokenLexer.php
+++ b/tests/Doctrine/Common/Lexer/ConcreteIntTokenLexer.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+use function in_array;
+use function is_numeric;
+use function is_string;
+
+class ConcreteIntTokenLexer extends AbstractLexer
+{
+    public const T_INT      = 1;
+    public const T_STRING   = 2;
+    public const T_OPERATOR = 3;
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCatchablePatterns()
+    {
+        return [
+            '=|<|>',
+            '[a-z]+',
+            '\d+',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getNonCatchablePatterns()
+    {
+        return [
+            '\s+',
+            '(.)',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getType(&$value)
+    {
+        if (is_numeric($value)) {
+            $value = (int) $value;
+
+            return self::T_INT;
+        }
+
+        if (in_array($value, ['=', '<', '>'])) {
+            return self::T_OPERATOR;
+        }
+
+        if (is_string($value)) {
+            return self::T_STRING;
+        }
+    }
+}


### PR DESCRIPTION
[TASK] Use proper docblock type for `AbstractLexer::isNextTokenAny()`

This patch changes the docblock type hint of `AbstractLexer::isNextTokenAny()`
to `list<int|string>` to adopt the int and string based support of token types.
Thus making phpstan in projects happy which uses this packages for there own
lexer implementations.

However this only aligns to other token methods which already supports int and
string as token types, thus fixing a wrong set type hint through #48.

Additionally a concrete lexer implementation was added to test a lexer implemention
with integer based tokens, adopted from the already string based implementation.

If this got accepted and merged, it would be nice to have a patchlevel release in
the nearer time.

Fixes: #62