### PR TITLE
[TASK] Allow execution of checks and quality tools on all branches

### DIFF
--- a/.github/workflows/coding-standards.yml
+++ b/.github/workflows/coding-standards.yml
@@ -3,11 +3,7 @@ name: "Coding Standards"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
   push:
-    branches:
-      - "*.x"
 
 jobs:
   coding-standards:

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -3,11 +3,7 @@ name: "Continuous Integration"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
   push:
-    branches:
-      - "*.x"
 
 jobs:
   phpunit:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -3,11 +3,7 @@ name: "Static Analysis"
 
 on:
   pull_request:
-    branches:
-      - "*.x"
   push:
-    branches:
-      - "*.x"
 
 jobs:
   static-analysis:


### PR DESCRIPTION
This change removes the branch contstrains for general
useful github workflowes, which helps contributers because
these tests can be run on forks. Thus allowing to have these
tests execute before opening a pull-request.

It is really annoying to open a pull request with a lot of
errors because it could not detected beforehand.