### PR TITLE
Memoize object construction and method call result

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -289,9 +289,9 @@ abstract class AbstractLexer
      */
     public function getLiteral($token)
     {
-        $className = static::class;
-        $reflClass = new ReflectionClass($className);
-        $constants = $reflClass->getConstants();
+        static $constants = null;
+        $className        = static::class;
+        $constants        = $constants ?? (new ReflectionClass($className))->getConstants();
 
         foreach ($constants as $name => $value) {
             if ($value === $token) {


### PR DESCRIPTION
### Description

The method `getLiteral($token)` currently creates a new `ReflectionClass` every time it's invoked, to get the constants defined on the static class.

This PR attempts to cache the first call and reuse it for subsequent calls.

### Diff

```diff
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
     public function getLiteral($token)
     {
+        static $constants = null;
         $className = static::class;
-        $reflClass = new ReflectionClass($className);
-        $constants = $reflClass->getConstants();
+        $constants = $constants ?? (new ReflectionClass($className))->getConstants();
```
once this package min support version is bumped to PHP 7.4

`$constants = $constants ?? (new ReflectionClass($className))->getConstants();` 

can later be optimized/shortened to

`$constants ??= (new ReflectionClass($className))->getConstants(); `