### PR TITLE
Added isCaughtByPattern & caughtByPatterns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.phpunit.result.cache
 /phpcs.xml
 /.phpcs-cache
+/.idea

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -6,7 +6,6 @@ namespace Doctrine\Common\Lexer;
 
 use ReflectionClass;
 
-use function count;
 use function implode;
 use function in_array;
 use function is_string;
@@ -315,9 +314,8 @@ abstract class AbstractLexer
         }
 
         $regex = sprintf('/(%s)/%s', $this->getCatchablePatterns()[$patternKey], $this->getModifiers());
-        preg_match($regex, $value, $matches);
 
-        return $matches && count($matches) > 0;
+        return (bool) preg_match($regex, $value);
     }
 
     /**

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -6,8 +6,11 @@ namespace Doctrine\Common\Lexer;
 
 use ReflectionClass;
 
+use function count;
 use function implode;
 use function in_array;
+use function is_string;
+use function preg_match;
 use function preg_split;
 use function sprintf;
 use function substr;
@@ -304,19 +307,15 @@ abstract class AbstractLexer
 
     /**
      * Checks if a given value was caught using a pattern in getCatchablePatterns
-     *
-     * @param $value
-     * @param $patternKey
-     * @return bool
      */
-    public function isCaughtByPattern($value, $patternKey): bool
+    public function isCaughtByPattern(?string $value, string $patternKey): bool
     {
-        if (!isset($this->getCatchablePatterns()[$patternKey]) || !is_string($value)) {
+        if (! isset($this->getCatchablePatterns()[$patternKey]) || ! is_string($value)) {
             return false;
         }
 
         $regex = sprintf('/(%s)/%s', $this->getCatchablePatterns()[$patternKey], $this->getModifiers());
-        preg_match($regex, $value,  $matches);
+        preg_match($regex, $value, $matches);
 
         return $matches && count($matches) >= 1;
     }
@@ -324,17 +323,18 @@ abstract class AbstractLexer
     /**
      * Checks if given a value was caught using by any of getCatchablePatterns
      *
-     * @param $value
-     * @return array
+     * @return string[]
      */
-    public function caughtByPatterns($value): array
+    public function caughtByPatterns(string $value): array
     {
         $catchables = [];
 
         foreach ($this->getCatchablePatterns() as $key => $pattern) {
-            if ($this->isCaughtByPattern($value, $key)) {
-                $catchables[] = $key;
+            if (! $this->isCaughtByPattern($value, $key)) {
+                continue;
             }
+
+            $catchables[] = $key;
         }
 
         return $catchables;

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -303,6 +303,44 @@ abstract class AbstractLexer
     }
 
     /**
+     * Checks if a given value was caught using a pattern in getCatchablePatterns
+     *
+     * @param $value
+     * @param $patternKey
+     * @return bool
+     */
+    public function isCaughtByPattern($value, $patternKey): bool
+    {
+        if (!isset($this->getCatchablePatterns()[$patternKey]) || !is_string($value)) {
+            return false;
+        }
+
+        $regex = sprintf('/(%s)/%s', $this->getCatchablePatterns()[$patternKey], $this->getModifiers());
+        preg_match($regex, $value,  $matches);
+
+        return $matches && count($matches) >= 1;
+    }
+
+    /**
+     * Checks if given a value was caught using by any of getCatchablePatterns
+     *
+     * @param $value
+     * @return array
+     */
+    public function caughtByPatterns($value): array
+    {
+        $catchables = [];
+
+        foreach ($this->getCatchablePatterns() as $key => $pattern) {
+            if ($this->isCaughtByPattern($value, $key)) {
+                $catchables[] = $key;
+            }
+        }
+
+        return $catchables;
+    }
+
+    /**
      * Regex modifiers
      *
      * @return string

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -317,7 +317,7 @@ abstract class AbstractLexer
         $regex = sprintf('/(%s)/%s', $this->getCatchablePatterns()[$patternKey], $this->getModifiers());
         preg_match($regex, $value, $matches);
 
-        return $matches && count($matches) >= 1;
+        return $matches && count($matches) > 0;
     }
 
     /**

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -370,7 +370,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @param int|string|null $type
+     * @param int|string $type
      *
      * @dataProvider cryptoAddressesProvider
      */

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -317,4 +317,61 @@ class AbstractLexerTest extends TestCase
         self::assertEquals('@', $mutableLexer->token['value']);
         self::assertEquals('ODM\Id', $mutableLexer->lookahead['value']);
     }
+
+    private function cryptoAddressesProvider()
+    {
+        return [
+            [
+                'address' => '16pe2twTgrjKC8mioPjX3f2UbCMGvWbVz4',
+                'type' => 'bitcoin',
+            ],
+            [
+                'address' => '12KYrjTdVGjFMtaxERSk3gphreJ5US8aUP',
+                'type' => 'bitcoin',
+            ],
+            [
+                'address' => 'bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4',
+                'type' => 'bitcoin',
+            ],
+            [
+                'address' => '17VZNX1SN5NtKa8UQFxwQbFeFc3iqRYhem',
+                'type' => 'bitcoin',
+            ],
+            [
+                // note: this is a valid bitcoin & litecoin address
+                'address' => '36nGbqV7XCNf2xepCLAtRBaqzTcSjF4sv9',
+                'type' => 'bitcoin',
+            ],
+            [
+                // note: this is a valid bitcoin & litecoin address
+                'address' => '3anGbqV7XCNf2xepCLAtRBaqzTcSjF4',
+                'type' => 'bitcoin',
+            ],
+            [
+                'address' => 'lanGbqV7XCNf2xepCLAtRBaqzTcSjF4',
+                'type' => 'litecoin',
+            ],
+            [
+                'address' => '0x71C7656EC7ab88b098defB751B7401B5f6d8976F',
+                'type' => 'ethereum',
+            ],
+            [
+                'address' => '12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2yAAAAAAA',
+                'type' => null,
+            ],
+        ];
+    }
+
+    /**
+     * @dataProvider cryptoAddressesProvider
+     * @param string $address
+     * @param string|null $type
+     * @return void
+     */
+    public function testIsCaughtByPattern(string $address, $type): void
+    {
+        $cryptocurrencyAddressLexer = new CryptocurrencyAddressLexer();
+
+        $this->assertTrue($cryptocurrencyAddressLexer->isA($address, $type));
+    }
 }

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -319,7 +319,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-return list<array{address: string, type: int|string|null}>
+     * @psalm-return list<array{address: string, type: int|string}>
      */
     public function cryptoAddressesProvider(): array
     {
@@ -360,11 +360,11 @@ class AbstractLexerTest extends TestCase
             ],
             [
                 'address' => '12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2yAAAAAAA',
-                'type' => null,
+                'type' => '',
             ],
             [
                 'address' => '',
-                'type' => null,
+                'type' => '',
             ],
         ];
     }

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -319,7 +319,6 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @return array
      * @psalm-return list<array{address: string, type: int|string|null}>
      */
     public function cryptoAddressesProvider(): array
@@ -361,6 +360,10 @@ class AbstractLexerTest extends TestCase
             ],
             [
                 'address' => '12QeMLzSrB8XH8FvEzPMVoRxVAzTr5XM2yAAAAAAA',
+                'type' => null,
+            ],
+            [
+                'address' => '',
                 'type' => null,
             ],
         ];

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -123,7 +123,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<ValidToken>  $expectedTokens
+     * @psalm-param list<ValidToken> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -318,7 +318,11 @@ class AbstractLexerTest extends TestCase
         self::assertEquals('ODM\Id', $mutableLexer->lookahead['value']);
     }
 
-    private function cryptoAddressesProvider()
+    /**
+     * @return array
+     * @psalm-return list<array{address: string, type: int|string|null}>
+     */
+    public function cryptoAddressesProvider(): array
     {
         return [
             [
@@ -338,12 +342,12 @@ class AbstractLexerTest extends TestCase
                 'type' => 'bitcoin',
             ],
             [
-                // note: this is a valid bitcoin & litecoin address
+                // @note: this is a valid bitcoin & litecoin address
                 'address' => '36nGbqV7XCNf2xepCLAtRBaqzTcSjF4sv9',
                 'type' => 'bitcoin',
             ],
             [
-                // note: this is a valid bitcoin & litecoin address
+                // @note: this is a valid bitcoin & litecoin address
                 'address' => '3anGbqV7XCNf2xepCLAtRBaqzTcSjF4',
                 'type' => 'bitcoin',
             ],
@@ -363,10 +367,9 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
+     * @param int|string|null $type
+     *
      * @dataProvider cryptoAddressesProvider
-     * @param string $address
-     * @param string|null $type
-     * @return void
      */
     public function testIsCaughtByPattern(string $address, $type): void
     {

--- a/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
+++ b/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
@@ -43,11 +43,7 @@ class CryptocurrencyAddressLexer extends AbstractLexer
     {
         $items = $this->caughtByPatterns($value);
 
-        if (count($items) === 0) {
-            return null;
-        }
-
-        return array_values($items)[0];
+        return array_values($items)[0] ?? null;
     }
 
     /**

--- a/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
+++ b/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+class CryptocurrencyAddressLexer extends AbstractLexer
+{
+    /** @var string[] */
+    private $catchablePatterns = [
+        'bitcoin' => '^(bc1|[13])[a-zA-HJ-NP-Z0-9]{25,39}$',
+        'litecoin' => '^[LM3][a-km-zA-HJ-NP-Z1-9]{26,33}$',
+        'ethereum' => '^0x[a-fA-F0-9]{40}$',
+    ];
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCatchablePatterns()
+    {
+        return $this->catchablePatterns;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getNonCatchablePatterns()
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritDoc}
+     * @return string|null
+     */
+    protected function getType(&$value)
+    {
+        $items = $this->caughtByPatterns($value);
+
+        if (count($items) === 0) {
+            return null;
+        }
+
+        return array_values($items)[0];
+
+        // @todo: discuss this possibility.
+        //if (count($items) === 1) {
+        //  return array_values($items)[0];
+        // }
+        //
+        // return $items;
+    }
+}

--- a/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
+++ b/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
@@ -37,19 +37,19 @@ class CryptocurrencyAddressLexer extends AbstractLexer
     /**
      * {@inheritDoc}
      *
-     * @return string|null
+     * @return string
      */
     protected function getType(&$value)
     {
         $items = $this->caughtByPatterns($value);
 
-        return array_values($items)[0] ?? null;
+        return array_values($items)[0] ?? '';
     }
 
     /**
      * @param string $value
      *
-     * @return string[]|string|null
+     * @return string[]|string
      *
      * @note This implementation needs to be discussed as the caughtByPatterns might return a string[],
      *        for now getType doesn't support returning array.
@@ -59,7 +59,7 @@ class CryptocurrencyAddressLexer extends AbstractLexer
         $items = $this->caughtByPatterns($value);
 
         if (count($items) === 0) {
-            return null;
+            return '';
         }
 
         if (count($items) === 1) {

--- a/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
+++ b/tests/Doctrine/Common/Lexer/CryptocurrencyAddressLexer.php
@@ -6,6 +6,9 @@ namespace Doctrine\Tests\Common\Lexer;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 
+use function array_values;
+use function count;
+
 class CryptocurrencyAddressLexer extends AbstractLexer
 {
     /** @var string[] */
@@ -33,6 +36,7 @@ class CryptocurrencyAddressLexer extends AbstractLexer
 
     /**
      * {@inheritDoc}
+     *
      * @return string|null
      */
     protected function getType(&$value)
@@ -44,12 +48,28 @@ class CryptocurrencyAddressLexer extends AbstractLexer
         }
 
         return array_values($items)[0];
+    }
 
-        // @todo: discuss this possibility.
-        //if (count($items) === 1) {
-        //  return array_values($items)[0];
-        // }
-        //
-        // return $items;
+    /**
+     * @param string $value
+     *
+     * @return string[]|string|null
+     *
+     * @note This implementation needs to be discussed as the caughtByPatterns might return a string[],
+     *        for now getType doesn't support returning array.
+     */
+    protected function getTypes(&$value)
+    {
+        $items = $this->caughtByPatterns($value);
+
+        if (count($items) === 0) {
+            return null;
+        }
+
+        if (count($items) === 1) {
+            return (string) array_values($items)[0];
+        }
+
+        return $items;
     }
 }


### PR DESCRIPTION
usage: Checks if the given value was caught using ```getCatchablePatterns``` key

benefits: Might be useful to use within ```getType``` method

* Example of implementation:
![carbon (3)](https://user-images.githubusercontent.com/14665300/203715466-f29da0b8-06e7-4443-82af-26ef01f75460.png)

* Example of usage:
![carbon (4)](https://user-images.githubusercontent.com/14665300/203716867-ece0f1c7-b511-4685-b711-f7171aa626b8.png)

