### PR TITLE
Replace object-like array with class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,14 @@
+Note about upgrading: Doctrine uses static and runtime mechanisms to raise
+awareness about deprecated code.
+
+- Use of `@deprecated` docblock that is detected by IDEs (like PHPStorm) or
+  Static Analysis tools (like Psalm, phpstan)
+- Use of our low-overhead runtime deprecation API, details:
+  https://github.com/doctrine/deprecations/
+
+# Upgrade to 1.3.0
+
+`AbstractLexer::glimpse()` and `AbstractLexer::peek()` now return
+instances of `Doctrine\Common\Lexer\Token`, which is an array-like class
+Using it as an array is deprecated in favor of using properties of that class.
+Using `count()` on it is deprecated with no replacement.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
         {"name": "Johannes Schmitt", "email": "schmittjoh@gmail.com"}
     ],
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.1 || ^8.0",
+        "doctrine/deprecations": "^1.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9 || ^10",

--- a/docs/en/dql-parser.rst
+++ b/docs/en/dql-parser.rst
@@ -250,7 +250,7 @@ Lexer implementation:
         {
             $this->lexer->moveNext();
 
-            switch ($this->lexer->lookahead['type']) {
+            switch ($this->lexer->lookahead->type) {
                 case Lexer::T_SELECT:
                     $statement = $this->SelectStatement();
                     break;

--- a/docs/en/simple-parser-example.rst
+++ b/docs/en/simple-parser-example.rst
@@ -72,8 +72,8 @@ Use ``CharacterTypeLexer`` to extract an array of upper case characters:
 
                 $this->lexer->moveNext();
 
-                if ($this->lexer->token['type'] === CharacterTypeLexer::T_UPPER) {
-                    $upperCaseChars[] = $this->lexer->token['value'];
+                if ($this->lexer->token->isA(CharacterTypeLexer::T_UPPER)) {
+                    $upperCaseChars[] = $this->lexer->token->value;
                 }
             }
 

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -7,7 +7,6 @@ namespace Doctrine\Common\Lexer;
 use ReflectionClass;
 
 use function implode;
-use function in_array;
 use function preg_split;
 use function sprintf;
 use function substr;
@@ -19,7 +18,7 @@ use const PREG_SPLIT_OFFSET_CAPTURE;
 /**
  * Base class for writing simple lexers, i.e. for creating small DSLs.
  *
- * @psalm-type Token = array{value: int|string, type:string|int|null, position:int}
+ * @template T of string|int
  */
 abstract class AbstractLexer
 {
@@ -33,14 +32,7 @@ abstract class AbstractLexer
     /**
      * Array of scanned tokens.
      *
-     * Each token is an associative array containing three items:
-     *  - 'value'    : the string value of the token in the input string
-     *  - 'type'     : the type of the token (identifier, numeric, string, input
-     *                 parameter, none)
-     *  - 'position' : the position of the token in the input string
-     *
-     * @var mixed[][]
-     * @psalm-var list<Token>
+     * @var list<Token<T>>
      */
     private $tokens = [];
 
@@ -62,7 +54,7 @@ abstract class AbstractLexer
      * The next token in the input.
      *
      * @var mixed[]|null
-     * @psalm-var Token|null
+     * @psalm-var Token<T>|null
      */
     public $lookahead;
 
@@ -70,7 +62,7 @@ abstract class AbstractLexer
      * The last matched/seen token.
      *
      * @var mixed[]|null
-     * @psalm-var Token|null
+     * @psalm-var Token<T>|null
      */
     public $token;
 
@@ -150,25 +142,25 @@ abstract class AbstractLexer
     /**
      * Checks whether a given token matches the current lookahead.
      *
-     * @param int|string $type
+     * @param T $type
      *
      * @return bool
      */
     public function isNextToken($type)
     {
-        return $this->lookahead !== null && $this->lookahead['type'] === $type;
+        return $this->lookahead !== null && $this->lookahead->isA($type);
     }
 
     /**
      * Checks whether any of the given tokens matches the current lookahead.
      *
-     * @param list<int|string> $types
+     * @param list<T> $types
      *
      * @return bool
      */
     public function isNextTokenAny(array $types)
     {
-        return $this->lookahead !== null && in_array($this->lookahead['type'], $types, true);
+        return $this->lookahead !== null && $this->lookahead->isA(...$types);
     }
 
     /**
@@ -195,7 +187,7 @@ abstract class AbstractLexer
      */
     public function skipUntil($type)
     {
-        while ($this->lookahead !== null && $this->lookahead['type'] !== $type) {
+        while ($this->lookahead !== null && ! $this->lookahead->isA($type)) {
             $this->moveNext();
         }
     }
@@ -217,7 +209,7 @@ abstract class AbstractLexer
      * Moves the lookahead token forward.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token|null
+     * @psalm-return Token<T>|null
      */
     public function peek()
     {
@@ -232,7 +224,7 @@ abstract class AbstractLexer
      * Peeks at the next token, returns it and immediately resets the peek.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token|null
+     * @psalm-return Token<T>|null
      */
     public function glimpse()
     {
@@ -272,11 +264,11 @@ abstract class AbstractLexer
             // Must remain before 'value' assignment since it can change content
             $type = $this->getType($match[0]);
 
-            $this->tokens[] = [
-                'value' => $match[0],
-                'type'  => $type,
-                'position' => $match[1],
-            ];
+            $this->tokens[] = new Token(
+                $match[0],
+                $type,
+                $match[1]
+            );
         }
     }
 
@@ -331,7 +323,7 @@ abstract class AbstractLexer
      *
      * @param string $value
      *
-     * @return int|string|null
+     * @return T|null
      */
     abstract protected function getType(&$value);
 }

--- a/lib/Doctrine/Common/Lexer/Token.php
+++ b/lib/Doctrine/Common/Lexer/Token.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Lexer;
+
+use ArrayAccess;
+use Countable;
+use Doctrine\Deprecations\Deprecation;
+use ReturnTypeWillChange;
+
+use function in_array;
+
+/**
+ * @template T of string|int
+ * @implements ArrayAccess<string,mixed>
+ */
+final class Token implements ArrayAccess, Countable
+{
+    /**
+     * The string value of the token in the input string
+     *
+     * @readonly
+     * @var string|int
+     */
+    public $value;
+
+    /**
+     * The type of the token (identifier, numeric, string, input parameter, none)
+     *
+     * @readonly
+     * @var T|null
+     */
+    public $type;
+
+    /**
+     * The position of the token in the input string
+     *
+     * @readonly
+     * @var int
+     */
+    public $position;
+
+    /**
+     * @param string|int $value
+     * @param T|null     $type
+     */
+    public function __construct($value, $type, int $position)
+    {
+        $this->value    = $value;
+        $this->type     = $type;
+        $this->position = $position;
+    }
+
+    /** @param T ...$types */
+    public function isA(...$types): bool
+    {
+        return in_array($this->type, $types, true);
+    }
+
+    /**
+     * @deprecated Use the value, type or position property instead
+     * {@inheritDoc}
+     */
+    public function offsetExists($offset): bool
+    {
+        Deprecation::trigger(
+            'doctrine/lexer',
+            'https://github.com/doctrine/lexer/pull/75',
+            'Accessing %s properties via ArrayAccess is deprecated, use the value, type or position property instead',
+            self::class
+        );
+
+        return in_array($offset, ['value', 'type', 'position'], true);
+    }
+
+    /**
+     * @deprecated Use the value, type or position property instead
+     * {@inheritDoc}
+     */
+    #[ReturnTypeWillChange]
+    public function offsetGet($offset)
+    {
+        Deprecation::trigger(
+            'doctrine/lexer',
+            'https://github.com/doctrine/lexer/pull/75',
+            'Accessing %s properties via ArrayAccess is deprecated, use the value, type or position property instead',
+            self::class
+        );
+
+        return $this->$offset;
+    }
+
+    /**
+     * @deprecated no replacement planned
+     * {@inheritDoc}
+     */
+    public function offsetSet($offset, $value): void
+    {
+        Deprecation::trigger(
+            'doctrine/lexer',
+            'https://github.com/doctrine/lexer/pull/75',
+            'Setting %s properties via ArrayAccess is deprecated',
+            self::class
+        );
+
+        $this->$offset = $value;
+    }
+
+    /**
+     * @deprecated no replacement planned
+     * {@inheritDoc}
+     */
+    public function offsetUnset($offset): void
+    {
+        Deprecation::trigger(
+            'doctrine/lexer',
+            'https://github.com/doctrine/lexer/pull/75',
+            'Setting %s properties via ArrayAccess is deprecated',
+            self::class
+        );
+
+        unset($this->$offset);
+    }
+
+    /**
+     * @deprecated no replacement planned
+     * {@inheritDoc}
+     */
+    public function count(): int
+    {
+        Deprecation::trigger(
+            'doctrine/lexer',
+            'https://github.com/doctrine/lexer/pull/75',
+            'Using count() on %s is deprecated',
+            self::class
+        );
+
+        return 3;
+    }
+}

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -183,7 +183,12 @@ class AbstractLexerTest extends TestCase
     {
         $this->concreteLexer->setInput($input);
         foreach ($expectedTokens as $expectedToken) {
-            $this->assertEquals($expectedToken, $this->concreteLexer->peek());
+            $actualToken = $this->concreteLexer->peek();
+            $this->assertEquals($expectedToken, $actualToken);
+            $this->assertSame($expectedToken['value'], $actualToken['value']);
+            $this->assertSame($expectedToken['type'], $actualToken['type']);
+            $this->assertSame($expectedToken['position'], $actualToken['position']);
+            $this->assertCount(3, $actualToken);
         }
 
         $this->assertNull($this->concreteLexer->peek());
@@ -199,7 +204,12 @@ class AbstractLexerTest extends TestCase
         $this->concreteLexer->setInput($input);
 
         foreach ($expectedTokens as $expectedToken) {
+            $actualToken = $this->concreteLexer->glimpse();
             $this->assertEquals($expectedToken, $this->concreteLexer->glimpse());
+            $this->assertSame($expectedToken['value'], $actualToken['value']);
+            $this->assertSame($expectedToken['type'], $actualToken['type']);
+            $this->assertSame($expectedToken['position'], $actualToken['position']);
+            $this->assertCount(3, $actualToken);
             $this->concreteLexer->moveNext();
         }
 

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Tests\Common\Lexer;
 
+use Doctrine\Common\Lexer\Token;
 use PHPUnit\Framework\TestCase;
 
 use function array_map;
@@ -12,9 +13,6 @@ use function setlocale;
 
 use const LC_ALL;
 
-/**
- * @psalm-type ValidToken = array{value: string|int, type: string|int, position: int}
- */
 class AbstractLexerTest extends TestCase
 {
     /** @var ConcreteLexer */
@@ -31,7 +29,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-return list<array{string, list<ValidToken>}>
+     * @psalm-return list<array{string, list<Token<string>>}>
      */
     public function dataProvider(): array
     {
@@ -39,21 +37,9 @@ class AbstractLexerTest extends TestCase
             [
                 'price=10',
                 [
-                    [
-                        'value' => 'price',
-                        'type' => 'string',
-                        'position' => 0,
-                    ],
-                    [
-                        'value' => '=',
-                        'type' => 'operator',
-                        'position' => 5,
-                    ],
-                    [
-                        'value' => 10,
-                        'type' => 'int',
-                        'position' => 6,
-                    ],
+                    new Token('price', 'string', 0),
+                    new Token('=', 'operator', 5),
+                    new Token(10, 'int', 6),
                 ],
             ],
         ];
@@ -62,21 +48,9 @@ class AbstractLexerTest extends TestCase
     public function testResetPeek(): void
     {
         $expectedTokens = [
-            [
-                'value' => 'price',
-                'type' => 'string',
-                'position' => 0,
-            ],
-            [
-                'value' => '=',
-                'type' => 'operator',
-                'position' => 5,
-            ],
-            [
-                'value' => 10,
-                'type' => 'int',
-                'position' => 6,
-            ],
+            new Token('price', 'string', 0),
+            new Token('=', 'operator', 5),
+            new Token(10, 'int', 6),
         ];
 
         $this->concreteLexer->setInput('price=10');
@@ -90,21 +64,9 @@ class AbstractLexerTest extends TestCase
     public function testResetPosition(): void
     {
         $expectedTokens = [
-            [
-                'value' => 'price',
-                'type' => 'string',
-                'position' => 0,
-            ],
-            [
-                'value' => '=',
-                'type' => 'operator',
-                'position' => 5,
-            ],
-            [
-                'value' => 10,
-                'type' => 'int',
-                'position' => 6,
-            ],
+            new Token('price', 'string', 0),
+            new Token('=', 'operator', 5),
+            new Token(10, 'int', 6),
         ];
 
         $this->concreteLexer->setInput('price=10');
@@ -123,7 +85,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<ValidToken>  $expectedTokens
+     * @psalm-param list<Token<string>>  $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -149,11 +111,7 @@ class AbstractLexerTest extends TestCase
         $this->concreteLexer->skipUntil('operator');
 
         $this->assertEquals(
-            [
-                'value' => '=',
-                'type' => 'operator',
-                'position' => 5,
-            ],
+            new Token('=', 'operator', 5),
             $this->concreteLexer->lookahead
         );
     }
@@ -165,17 +123,13 @@ class AbstractLexerTest extends TestCase
         $this->assertTrue($this->concreteLexer->moveNext());
 
         $this->assertEquals(
-            [
-                'value' => "\xE9=10",
-                'type' => 'string',
-                'position' => 0,
-            ],
+            new Token("\xE9=10", 'string', 0),
             $this->concreteLexer->lookahead
         );
     }
 
     /**
-     * @psalm-param list<ValidToken> $expectedTokens
+     * @psalm-param list<Token<string>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -195,7 +149,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<ValidToken> $expectedTokens
+     * @psalm-param list<Token<string>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -240,7 +194,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<ValidToken> $expectedTokens
+     * @psalm-param list<Token<string>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -250,27 +204,27 @@ class AbstractLexerTest extends TestCase
 
         $this->concreteLexer->moveNext();
         for ($i = 0; $i < count($expectedTokens); $i++) {
-            $this->assertTrue($this->concreteLexer->isNextToken($expectedTokens[$i]['type']));
+            $this->assertTrue($this->concreteLexer->isNextToken($expectedTokens[$i]->type));
             $this->concreteLexer->moveNext();
         }
     }
 
     /**
-     * @psalm-param list<ValidToken> $expectedTokens
+     * @psalm-param list<Token<string>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
     public function testIsNextTokenAny(string $input, array $expectedTokens): void
     {
         $allTokenTypes = array_map(static function ($token) {
-            return $token['type'];
+            return $token->type;
         }, $expectedTokens);
 
         $this->concreteLexer->setInput($input);
 
         $this->concreteLexer->moveNext();
         for ($i = 0; $i < count($expectedTokens); $i++) {
-            $this->assertTrue($this->concreteLexer->isNextTokenAny([$expectedTokens[$i]['type']]));
+            $this->assertTrue($this->concreteLexer->isNextTokenAny([$expectedTokens[$i]->type]));
             $this->assertTrue($this->concreteLexer->isNextTokenAny($allTokenTypes));
             $this->concreteLexer->moveNext();
         }
@@ -299,14 +253,14 @@ class AbstractLexerTest extends TestCase
         $mutableLexer->setInput('one');
         $token = $mutableLexer->glimpse();
 
-        $this->assertEquals('o', $token['value']);
+        $this->assertEquals('o', $token->value);
 
         $mutableLexer = new MutableLexer();
         $mutableLexer->addCatchablePattern('[a-z]+');
         $mutableLexer->setInput('one');
         $token = $mutableLexer->glimpse();
 
-        $this->assertEquals('one', $token['value']);
+        $this->assertEquals('one', $token->value);
     }
 
     public function testMarkerAnnotationLocaleTr(): void
@@ -323,10 +277,10 @@ class AbstractLexerTest extends TestCase
         self::assertTrue($mutableLexer->moveNext());
         self::assertNull($mutableLexer->token);
         self::assertNotNull($mutableLexer->lookahead);
-        self::assertEquals('@', $mutableLexer->lookahead['value']);
+        self::assertEquals('@', $mutableLexer->lookahead->value);
         self::assertTrue($mutableLexer->moveNext());
         self::assertNotNull($mutableLexer->token);
-        self::assertEquals('@', $mutableLexer->token['value']);
-        self::assertEquals('ODM\Id', $mutableLexer->lookahead['value']);
+        self::assertEquals('@', $mutableLexer->token->value);
+        self::assertEquals('ODM\Id', $mutableLexer->lookahead->value);
     }
 }

--- a/tests/Doctrine/Common/Lexer/ConcreteLexer.php
+++ b/tests/Doctrine/Common/Lexer/ConcreteLexer.php
@@ -10,6 +10,7 @@ use function in_array;
 use function is_numeric;
 use function is_string;
 
+/** @extends AbstractLexer<string> */
 class ConcreteLexer extends AbstractLexer
 {
     public const INT = 'int';

--- a/tests/Doctrine/Common/Lexer/MutableLexer.php
+++ b/tests/Doctrine/Common/Lexer/MutableLexer.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\Lexer;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 
+/** @extends AbstractLexer<int> */
 class MutableLexer extends AbstractLexer
 {
     /** @var string[] */

--- a/tests/Doctrine/Common/Lexer/TokenTest.php
+++ b/tests/Doctrine/Common/Lexer/TokenTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\Token;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+final class TokenTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testIsA(): void
+    {
+        $token = new Token('foo', 'string', 1);
+
+        self::assertTrue($token->isA('string'));
+        self::assertTrue($token->isA('int', 'string'));
+        self::assertFalse($token->isA('int'));
+    }
+
+    public function testArrayAccessIsDeprecated(): void
+    {
+        $token = new Token('foo', 'string', 1);
+        self::expectDeprecationWithIdentifier('https://github.com/doctrine/lexer/pull/75');
+        self::assertSame('foo', $token['value']);
+    }
+
+    public function testCountIsDeprecated(): void
+    {
+        $token = new Token('foo', 'string', 1);
+
+        self::expectDeprecationWithIdentifier('https://github.com/doctrine/lexer/pull/75');
+
+        self::assertCount(3, $token);
+    }
+}


### PR DESCRIPTION
The new class is templatable, which should enable us to specify that the ORM Lexer is an `Lexer<self::T_*>`, and in the future, define an enum called TokenType in the ORM, and switch to `Lexer<TokenType>`.

Also, I haven't check but I believe it's better memory-wise to use objects rather than arrays.

The assumption I'm making here is that token are used as object-like arrays, and not with e.g. `foreach` or `count()`