### PR TITLE
Allow using enums as a token type

### DIFF
--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -5,7 +5,9 @@ declare(strict_types=1);
 namespace Doctrine\Common\Lexer;
 
 use ReflectionClass;
+use UnitEnum;
 
+use function get_class;
 use function implode;
 use function preg_split;
 use function sprintf;
@@ -18,7 +20,7 @@ use const PREG_SPLIT_OFFSET_CAPTURE;
 /**
  * Base class for writing simple lexers, i.e. for creating small DSLs.
  *
- * @template T of string|int
+ * @template T of UnitEnum|string|int
  */
 abstract class AbstractLexer
 {
@@ -275,13 +277,18 @@ abstract class AbstractLexer
     /**
      * Gets the literal for a given token.
      *
-     * @param int|string $token
+     * @param T $token
      *
      * @return int|string
      */
     public function getLiteral($token)
     {
+        if ($token instanceof UnitEnum) {
+            return get_class($token) . '::' . $token->name;
+        }
+
         $className = static::class;
+
         $reflClass = new ReflectionClass($className);
         $constants = $reflClass->getConstants();
 

--- a/lib/Doctrine/Common/Lexer/Token.php
+++ b/lib/Doctrine/Common/Lexer/Token.php
@@ -7,11 +7,12 @@ namespace Doctrine\Common\Lexer;
 use ArrayAccess;
 use Doctrine\Deprecations\Deprecation;
 use ReturnTypeWillChange;
+use UnitEnum;
 
 use function in_array;
 
 /**
- * @template T of string|int
+ * @template T of UnitEnum|string|int
  * @implements ArrayAccess<string,mixed>
  */
 final class Token implements ArrayAccess

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -234,6 +234,18 @@ class AbstractLexerTest extends TestCase
         $this->assertSame('fake_token', $this->concreteLexer->getLiteral('fake_token'));
     }
 
+    /**
+     * @requires PHP 8.1
+     */
+    public function testGetLiteralWithEnumLexer(): void
+    {
+        $enumLexer = new EnumLexer();
+        $this->assertSame(
+            'Doctrine\Tests\Common\Lexer\TokenType::OPERATOR',
+            $enumLexer->getLiteral(TokenType::OPERATOR)
+        );
+    }
+
     public function testIsA(): void
     {
         $this->assertTrue($this->concreteLexer->isA(11, 'int'));

--- a/tests/Doctrine/Common/Lexer/EnumLexer.php
+++ b/tests/Doctrine/Common/Lexer/EnumLexer.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\AbstractLexer;
+
+use function in_array;
+use function is_numeric;
+use function is_string;
+
+/** @extends AbstractLexer<TokenType> */
+class EnumLexer extends AbstractLexer
+{
+    /**
+     * {@inheritDoc}
+     */
+    protected function getCatchablePatterns(): array
+    {
+        return [
+            '=|<|>',
+            '[a-z]+',
+            '\d+',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getNonCatchablePatterns(): array
+    {
+        return [
+            '\s+',
+            '(.)',
+        ];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    protected function getType(&$value): TokenType
+    {
+        if (is_numeric($value)) {
+            $value = (int) $value;
+
+            return TokenType::INT;
+        }
+
+        if (in_array($value, ['=', '<', '>'])) {
+            return TokenType::OPERATOR;
+        }
+
+        if (is_string($value)) {
+            return TokenType::STRING;
+        }
+    }
+}

--- a/tests/Doctrine/Common/Lexer/TokenType.php
+++ b/tests/Doctrine/Common/Lexer/TokenType.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+enum TokenType
+{
+    case INT;
+    case OPERATOR;
+    case STRING;
+}


### PR DESCRIPTION
Enums allow to avoid having to come up with values to assign for each name (unless you use a backed enum), and will provide more type safety.

There is a small performance impact:

```
PHPBench (1.2.7) running benchmarks... #standwithukraine
with configuration file: /home/greg/dev/doctrine-lexer/phpbench.json
with PHP version 8.1.12, xdebug ❌, opcache ❌
comparing [actual vs. original]

\Doctrine\Lexer\Benchmark\LexerBench

    benchLexer..............................I0 - [Mo10.680μs vs. Mo10.611μs] +0.65% (±0.00%)

Subjects: 1, Assertions: 0, Failures: 0, Errors: 0
+------------+------------+-----+--------+-----+---------------+-----------------+--------------+
| benchmark  | subject    | set | revs   | its | mem_peak      | mode            | rstdev       |
+------------+------------+-----+--------+-----+---------------+-----------------+--------------+
| LexerBench | benchLexer |     | 100000 | 1   | 1.723mb 0.00% | 10.680μs +0.65% | ±0.00% 0.00% |
+------------+------------+-----+--------+-----+---------------+-----------------+--------------+
```