### PR TITLE
Replace object-like array with class

### DIFF
--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,14 @@
+Note about upgrading: Doctrine uses static and runtime mechanisms to raise
+awareness about deprecated code.
+
+- Use of `@deprecated` docblock that is detected by IDEs (like PHPStorm) or
+  Static Analysis tools (like Psalm, phpstan)
+- Use of our low-overhead runtime deprecation API, details:
+  https://github.com/doctrine/deprecations/
+
+# Upgrade to 2.0.0
+
+`AbstractLexer::glimpse()` and `AbstractLexer::peek()` now will return
+instances of `Doctrine\Common\Lexer\Token` when passing `true` to
+`AbstractLexer::__construct()`.
+Not passing `true` is deprecated.

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,8 @@
     ],
     "homepage": "https://www.doctrine-project.org/projects/lexer.html",
     "require": {
-        "php": "^7.1 || ^8.0"
+        "php": "^7.1 || ^8.0",
+        "doctrine/deprecations": "^1.0"
     },
     "require-dev": {
         "doctrine/coding-standard": "^9 || ^10",

--- a/docs/en/dql-parser.rst
+++ b/docs/en/dql-parser.rst
@@ -254,7 +254,7 @@ Lexer implementation:
         {
             $this->lexer->moveNext();
 
-            switch ($this->lexer->lookahead['type']) {
+            switch ($this->lexer->lookahead->type) {
                 case Lexer::T_SELECT:
                     $statement = $this->SelectStatement();
                     break;

--- a/docs/en/simple-parser-example.rst
+++ b/docs/en/simple-parser-example.rst
@@ -70,8 +70,8 @@ Use ``CharacterTypeLexer`` to extract an array of upper case characters:
 
                 $this->lexer->moveNext();
 
-                if ($this->lexer->token['type'] === CharacterTypeLexer::T_UPPER) {
-                    $upperCaseChars[] = $this->lexer->token['value'];
+                if ($this->lexer->token->isA(CharacterTypeLexer::T_UPPER)) {
+                    $upperCaseChars[] = $this->lexer->token->value;
                 }
             }
 

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Doctrine\Common\Lexer;
 
+use Doctrine\Deprecations\Deprecation;
 use ReflectionClass;
 
 use function implode;
@@ -19,7 +20,8 @@ use const PREG_SPLIT_OFFSET_CAPTURE;
 /**
  * Base class for writing simple lexers, i.e. for creating small DSLs.
  *
- * @psalm-type Token = array{value: int|string, type:string|int|null, position:int}
+ * @psalm-type ArrayToken = array{value: int|string, type:string|int|null, position:int}
+ * @template T of string|int
  */
 abstract class AbstractLexer
 {
@@ -33,14 +35,7 @@ abstract class AbstractLexer
     /**
      * Array of scanned tokens.
      *
-     * Each token is an associative array containing three items:
-     *  - 'value'    : the string value of the token in the input string
-     *  - 'type'     : the type of the token (identifier, numeric, string, input
-     *                 parameter, none)
-     *  - 'position' : the position of the token in the input string
-     *
-     * @var mixed[][]
-     * @psalm-var list<Token>
+     * @var list<Token<T>>|list<ArrayToken>
      */
     private $tokens = [];
 
@@ -62,7 +57,7 @@ abstract class AbstractLexer
      * The next token in the input.
      *
      * @var mixed[]|null
-     * @psalm-var Token|null
+     * @psalm-var Token<T>|ArrayToken|null
      */
     public $lookahead;
 
@@ -70,7 +65,7 @@ abstract class AbstractLexer
      * The last matched/seen token.
      *
      * @var mixed[]|null
-     * @psalm-var Token|null
+     * @psalm-var Token<T>|ArrayToken|null
      */
     public $token;
 
@@ -80,6 +75,23 @@ abstract class AbstractLexer
      * @var string|null
      */
     private $regex;
+
+    /** @var bool */
+    private $useObjectTokens;
+
+    public function __construct(bool $useObjectTokens = false)
+    {
+        if (! $useObjectTokens) {
+            Deprecation::trigger(
+                'doctrine/lexer',
+                'https://github.com/doctrine/lexer/pull/81',
+                'Omitting to opt-in to object tokens via $useObjectTokens in %s is deprecated',
+                __METHOD__
+            );
+        }
+
+        $this->useObjectTokens = $useObjectTokens;
+    }
 
     /**
      * Sets the input data to be tokenized.
@@ -150,25 +162,33 @@ abstract class AbstractLexer
     /**
      * Checks whether a given token matches the current lookahead.
      *
-     * @param int|string $type
+     * @param T $type
      *
      * @return bool
      */
     public function isNextToken($type)
     {
-        return $this->lookahead !== null && $this->lookahead['type'] === $type;
+        if (! $this->useObjectTokens) {
+            return $this->lookahead !== null && $this->lookahead['type'] === $type;
+        }
+
+        return $this->lookahead !== null && $this->lookahead->isA($type);
     }
 
     /**
      * Checks whether any of the given tokens matches the current lookahead.
      *
-     * @param list<int|string> $types
+     * @param list<T> $types
      *
      * @return bool
      */
     public function isNextTokenAny(array $types)
     {
-        return $this->lookahead !== null && in_array($this->lookahead['type'], $types, true);
+        if (! $this->useObjectTokens) {
+            return $this->lookahead !== null && in_array($this->lookahead['type'], $types, true);
+        }
+
+        return $this->lookahead !== null && $this->lookahead->isA(...$types);
     }
 
     /**
@@ -189,13 +209,21 @@ abstract class AbstractLexer
     /**
      * Tells the lexer to skip input tokens until it sees a token with the given value.
      *
-     * @param string $type The token type to skip until.
+     * @param T $type The token type to skip until.
      *
      * @return void
      */
     public function skipUntil($type)
     {
-        while ($this->lookahead !== null && $this->lookahead['type'] !== $type) {
+        if (! $this->useObjectTokens) {
+            while ($this->lookahead !== null && $this->lookahead['type'] !== $type) {
+                $this->moveNext();
+            }
+
+            return;
+        }
+
+        while ($this->lookahead !== null && ! $this->lookahead->isA($type)) {
             $this->moveNext();
         }
     }
@@ -217,7 +245,7 @@ abstract class AbstractLexer
      * Moves the lookahead token forward.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token|null
+     * @psalm-return Token<T>|ArrayToken|null
      */
     public function peek()
     {
@@ -232,7 +260,7 @@ abstract class AbstractLexer
      * Peeks at the next token, returns it and immediately resets the peek.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token|null
+     * @psalm-return Token<T>|ArrayToken|null
      */
     public function glimpse()
     {
@@ -272,7 +300,11 @@ abstract class AbstractLexer
             // Must remain before 'value' assignment since it can change content
             $type = $this->getType($match[0]);
 
-            $this->tokens[] = [
+            $this->tokens[] = $this->useObjectTokens ? new Token(
+                $match[0],
+                $type,
+                $match[1]
+            ) : [
                 'value' => $match[0],
                 'type'  => $type,
                 'position' => $match[1],
@@ -331,7 +363,7 @@ abstract class AbstractLexer
      *
      * @param string $value
      *
-     * @return int|string|null
+     * @return T|null
      */
     abstract protected function getType(&$value);
 }

--- a/lib/Doctrine/Common/Lexer/Token.php
+++ b/lib/Doctrine/Common/Lexer/Token.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Common\Lexer;
+
+use function in_array;
+
+/** @template T of string|int */
+final class Token
+{
+    /**
+     * The string value of the token in the input string
+     *
+     * @readonly
+     * @var string|int
+     */
+    public $value;
+
+    /**
+     * The type of the token (identifier, numeric, string, input parameter, none)
+     *
+     * @readonly
+     * @var T|null
+     */
+    public $type;
+
+    /**
+     * The position of the token in the input string
+     *
+     * @readonly
+     * @var int
+     */
+    public $position;
+
+    /**
+     * @param string|int $value
+     * @param T|null     $type
+     */
+    public function __construct($value, $type, int $position)
+    {
+        $this->value    = $value;
+        $this->type     = $type;
+        $this->position = $position;
+    }
+
+    /** @param T ...$types */
+    public function isA(...$types): bool
+    {
+        return in_array($this->type, $types, true);
+    }
+}

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,10 @@ parameters:
   paths:
     - %rootDir%/../../../lib
     - %rootDir%/../../../tests
+  ignoreErrors:
+    -
+       message: "/^Cannot access offset 'type'.*/"
+       path: lib/Doctrine/Common/Lexer/AbstractLexer.php
+    -
+       message: "/^Cannot call method isA.*/"
+       path: lib/Doctrine/Common/Lexer/AbstractLexer.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -12,4 +12,11 @@
             <directory name="vendor" />
         </ignoreFiles>
     </projectFiles>
+    <issueHandlers>
+        <UndefinedMethod>
+            <errorLevel type="suppress">
+                <referencedMethod name="Doctrine\Common\Lexer\Token::offsetGet"/>
+            </errorLevel>
+        </UndefinedMethod>
+    </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Common/Lexer/ConcreteLexer.php
+++ b/tests/Doctrine/Common/Lexer/ConcreteLexer.php
@@ -10,6 +10,7 @@ use function in_array;
 use function is_numeric;
 use function is_string;
 
+/** @extends AbstractLexer<string> */
 class ConcreteLexer extends AbstractLexer
 {
     public const INT = 'int';

--- a/tests/Doctrine/Common/Lexer/MutableLexer.php
+++ b/tests/Doctrine/Common/Lexer/MutableLexer.php
@@ -6,6 +6,7 @@ namespace Doctrine\Tests\Common\Lexer;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 
+/** @extends AbstractLexer<int> */
 class MutableLexer extends AbstractLexer
 {
     /** @var string[] */

--- a/tests/Doctrine/Common/Lexer/TokenTest.php
+++ b/tests/Doctrine/Common/Lexer/TokenTest.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Doctrine\Tests\Common\Lexer;
+
+use Doctrine\Common\Lexer\Token;
+use Doctrine\Deprecations\PHPUnit\VerifyDeprecations;
+use PHPUnit\Framework\TestCase;
+
+final class TokenTest extends TestCase
+{
+    use VerifyDeprecations;
+
+    public function testIsA(): void
+    {
+        $token = new Token('foo', 'string', 1);
+
+        self::assertTrue($token->isA('string'));
+        self::assertTrue($token->isA('int', 'string'));
+        self::assertFalse($token->isA('int'));
+    }
+}


### PR DESCRIPTION
Alternative to https://github.com/doctrine/lexer/pull/79 (which I still prefer)

The new class is templatable, which should enable us to specify that the ORM Lexer is an `Lexer<self::T_*>`, and in the future, define an enum called TokenType in the ORM, and switch to `Lexer<TokenType>`.

I tested on the ORM, and with this solution, the PHPUnit test suite no longer breaks.

The static analysis is broken because of the impossibility to know if we have an array or an object, and because I want to reuse the `Token` name.

I've considered adding another template param to `AbstractLexer` to fix this, but then it would have to be removed in 2.0, which would make implementing compatibility with 2.0 challenging from the SA point of view.