### PR TITLE
Stricter sa

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
         "doctrine/coding-standard": "^9 || ^10",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+        "psalm/plugin-phpunit": "^0.18.3",
         "vimeo/psalm": "^4.11 || ^5.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
         "doctrine/coding-standard": "^9 || ^10",
         "phpstan/phpstan": "^1.3",
         "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-        "vimeo/psalm": "^4.11"
+        "vimeo/psalm": "^4.11 || ^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/lib/Doctrine/Common/Lexer/AbstractLexer.php
+++ b/lib/Doctrine/Common/Lexer/AbstractLexer.php
@@ -203,7 +203,7 @@ abstract class AbstractLexer
     /**
      * Checks if given value is identical to the given token.
      *
-     * @param mixed      $value
+     * @param string     $value
      * @param int|string $token
      *
      * @return bool

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,5 +1,5 @@
 parameters:
-  level: 7
+  level: max
   paths:
     - %rootDir%/../../../lib
     - %rootDir%/../../../tests

--- a/psalm.xml
+++ b/psalm.xml
@@ -1,15 +1,26 @@
 <?xml version="1.0"?>
 <psalm
-    errorLevel="5"
+    errorLevel="1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"
     xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
 >
     <projectFiles>
-        <directory name="lib/Doctrine/Common/Lexer" />
+        <directory name="lib/Doctrine/Common/Lexer"/>
+        <directory name="tests/Doctrine/Common/Lexer"/>
         <ignoreFiles>
-            <directory name="vendor" />
+            <directory name="vendor"/>
         </ignoreFiles>
     </projectFiles>
+    <plugins>
+        <pluginClass class="Psalm\PhpUnitPlugin\Plugin"/>
+    </plugins>
+    <issueHandlers>
+        <MixedAssignment>
+            <errorLevel type="suppress">
+                <file name="lib/Doctrine/Common/Lexer/AbstractLexer.php" />
+            </errorLevel>
+        </MixedAssignment>
+    </issueHandlers>
 </psalm>

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -274,8 +274,8 @@ class AbstractLexerTest extends TestCase
 
     public function testIsA(): void
     {
-        $this->assertTrue($this->concreteLexer->isA(11, 'int'));
-        $this->assertTrue($this->concreteLexer->isA(1.1, 'int'));
+        $this->assertTrue($this->concreteLexer->isA('11', 'int'));
+        $this->assertTrue($this->concreteLexer->isA('1.1', 'int'));
         $this->assertTrue($this->concreteLexer->isA('=', 'operator'));
         $this->assertTrue($this->concreteLexer->isA('>', 'operator'));
         $this->assertTrue($this->concreteLexer->isA('<', 'operator'));

--- a/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
+++ b/tests/Doctrine/Common/Lexer/AbstractLexerTest.php
@@ -289,6 +289,7 @@ class AbstractLexerTest extends TestCase
         $mutableLexer->setInput('one');
         $token = $mutableLexer->glimpse();
 
+        $this->assertNotNull($token);
         $this->assertEquals('o', $token['value']);
 
         $mutableLexer = new MutableLexer();
@@ -296,6 +297,7 @@ class AbstractLexerTest extends TestCase
         $mutableLexer->setInput('one');
         $token = $mutableLexer->glimpse();
 
+        $this->assertNotNull($token);
         $this->assertEquals('one', $token['value']);
     }
 

--- a/tests/Doctrine/Common/Lexer/ConcreteLexer.php
+++ b/tests/Doctrine/Common/Lexer/ConcreteLexer.php
@@ -8,7 +8,6 @@ use Doctrine\Common\Lexer\AbstractLexer;
 
 use function in_array;
 use function is_numeric;
-use function is_string;
 
 class ConcreteLexer extends AbstractLexer
 {
@@ -52,8 +51,6 @@ class ConcreteLexer extends AbstractLexer
             return 'operator';
         }
 
-        if (is_string($value)) {
-            return 'string';
-        }
+        return 'string';
     }
 }


### PR DESCRIPTION
I was looking for a way to catch the discrepancy between `isA()`'s signature and `getType()` signature.