### PR TITLE
Leverage conditional types

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -47,6 +47,11 @@
                 <file name="src/AbstractLexer.php" />
             </errorLevel>
         </MixedAssignment>
+        <MixedReturnStatement>
+            <errorLevel type="suppress">
+                <file name="src/Token.php" />
+            </errorLevel>
+        </MixedReturnStatement>
         <RedundantConditionGivenDocblockType>
             <errorLevel type="suppress">
                 <!-- that test checks non-obvious things guaranteed by static analysis, just in case -->

--- a/src/Token.php
+++ b/src/Token.php
@@ -78,9 +78,24 @@ final class Token implements ArrayAccess
      * @deprecated Use the value, type or position property instead
      * {@inheritDoc}
      *
-     * @param array-key $offset
+     * @param O $offset
      *
      * @return mixed
+     * @psalm-return (
+     *     O is 'value'
+     *     ? string|int
+     *     : (
+     *         O is 'type'
+     *         ? T|null
+     *         : (
+     *             O is 'position'
+     *             ? int
+     *             : mixed
+     *         )
+     *     )
+     * )
+     *
+     * @template O of array-key
      */
     #[ReturnTypeWillChange]
     public function offsetGet($offset)


### PR DESCRIPTION
This should help downstream projects stop wondering if null checks are necessary.

For instance, when I try running Psalm on `doctrine/orm` with `2.1.x@dev`, at the moment I still get 100 errors despite #95 . A lot of them are about possibly null arguments, when the argument is `$someToken['value']`.