### PR TITLE
Make the value of tokens templatable

### DIFF
--- a/docs/en/simple-parser-example.rst
+++ b/docs/en/simple-parser-example.rst
@@ -11,6 +11,9 @@ It tokenizes a string to ``T_UPPER``, ``T_LOWER`` and``T_NUMBER`` tokens:
 
     use Doctrine\Common\Lexer\AbstractLexer;
 
+    /**
+     * @extends AbstractLexer<CharacterTypeLexer::T_*, string>
+     */
     class CharacterTypeLexer extends AbstractLexer
     {
         const T_UPPER =  1;

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -3,3 +3,11 @@ parameters:
   paths:
     - %rootDir%/../../../src
     - %rootDir%/../../../tests
+
+  ignoreErrors:
+    -
+      message: '#^Property Doctrine\\Common\\Lexer\\AbstractLexer\<T of int\|string\|UnitEnum,V of int\|string\>\:\:\$tokens \(array\<int, Doctrine\\Common\\Lexer\\Token\<T of int\|string\|UnitEnum, V of int\|string\>\>\) does not accept non\-empty\-array\<int, Doctrine\\Common\\Lexer\\Token\<T of int\|string\|UnitEnum, int\|string\>\>\.$#'
+      path: src/AbstractLexer.php
+    -
+      message: '#^Method Doctrine\\Tests\\Common\\Lexer\\AbstractLexerTest\:\:dataProvider\(\) should return array\<int, array\{string, array\<int, Doctrine\\Common\\Lexer\\Token\<string, int\|string\>\>\}\> but returns array\{array\{''price\=10'', array\{Doctrine\\Common\\Lexer\\Token\<string, string\>, Doctrine\\Common\\Lexer\\Token\<string, string\>, Doctrine\\Common\\Lexer\\Token\<string, int\>\}\}\}\.$#'
+      path: tests/AbstractLexerTest.php

--- a/psalm.xml
+++ b/psalm.xml
@@ -52,6 +52,12 @@
                 <file name="src/Token.php" />
             </errorLevel>
         </MixedReturnStatement>
+        <ReferenceConstraintViolation>
+            <errorLevel type="suppress">
+                <!-- https://github.com/vimeo/psalm/issues/8891 -->
+                <file name="src/AbstractLexer.php" />
+            </errorLevel>
+        </ReferenceConstraintViolation>
         <RedundantConditionGivenDocblockType>
             <errorLevel type="suppress">
                 <!-- that test checks non-obvious things guaranteed by static analysis, just in case -->

--- a/src/AbstractLexer.php
+++ b/src/AbstractLexer.php
@@ -21,6 +21,7 @@ use const PREG_SPLIT_OFFSET_CAPTURE;
  * Base class for writing simple lexers, i.e. for creating small DSLs.
  *
  * @template T of UnitEnum|string|int
+ * @template V of string|int
  */
 abstract class AbstractLexer
 {
@@ -34,7 +35,7 @@ abstract class AbstractLexer
     /**
      * Array of scanned tokens.
      *
-     * @var list<Token<T>>
+     * @var list<Token<T, V>>
      */
     private $tokens = [];
 
@@ -56,7 +57,7 @@ abstract class AbstractLexer
      * The next token in the input.
      *
      * @var mixed[]|null
-     * @psalm-var Token<T>|null
+     * @psalm-var Token<T, V>|null
      */
     public $lookahead;
 
@@ -64,7 +65,7 @@ abstract class AbstractLexer
      * The last matched/seen token.
      *
      * @var mixed[]|null
-     * @psalm-var Token<T>|null
+     * @psalm-var Token<T, V>|null
      */
     public $token;
 
@@ -218,7 +219,7 @@ abstract class AbstractLexer
      * Moves the lookahead token forward.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token<T>|null
+     * @psalm-return Token<T, V>|null
      */
     public function peek()
     {
@@ -233,7 +234,7 @@ abstract class AbstractLexer
      * Peeks at the next token, returns it and immediately resets the peek.
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token<T>|null
+     * @psalm-return Token<T, V>|null
      */
     public function glimpse()
     {
@@ -271,10 +272,11 @@ abstract class AbstractLexer
 
         foreach ($matches as $match) {
             // Must remain before 'value' assignment since it can change content
-            $type = $this->getType($match[0]);
+            $firstMatch = $match[0];
+            $type       = $this->getType($firstMatch);
 
             $this->tokens[] = new Token(
-                $match[0],
+                $firstMatch,
                 $type,
                 $match[1]
             );
@@ -338,6 +340,8 @@ abstract class AbstractLexer
      * @param string $value
      *
      * @return T|null
+     *
+     * @param-out V $value
      */
     abstract protected function getType(&$value);
 }

--- a/src/Token.php
+++ b/src/Token.php
@@ -13,6 +13,7 @@ use function in_array;
 
 /**
  * @template T of UnitEnum|string|int
+ * @template V of string|int
  * @implements ArrayAccess<string,mixed>
  */
 final class Token implements ArrayAccess
@@ -21,7 +22,7 @@ final class Token implements ArrayAccess
      * The string value of the token in the input string
      *
      * @readonly
-     * @var string|int
+     * @var V
      */
     public $value;
 
@@ -42,8 +43,8 @@ final class Token implements ArrayAccess
     public $position;
 
     /**
-     * @param string|int $value
-     * @param T|null     $type
+     * @param V      $value
+     * @param T|null $type
      */
     public function __construct($value, $type, int $position)
     {
@@ -83,7 +84,7 @@ final class Token implements ArrayAccess
      * @return mixed
      * @psalm-return (
      *     O is 'value'
-     *     ? string|int
+     *     ? V
      *     : (
      *         O is 'type'
      *         ? T|null

--- a/tests/AbstractLexerTest.php
+++ b/tests/AbstractLexerTest.php
@@ -30,7 +30,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-return list<array{string, list<Token<string>>}>
+     * @psalm-return list<array{string, list<Token<string, string|int>>}>
      */
     public function dataProvider(): array
     {
@@ -86,7 +86,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<Token<string>>  $expectedTokens
+     * @psalm-param list<Token<string, string|int>>  $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -130,7 +130,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<Token<string>> $expectedTokens
+     * @psalm-param list<Token<string, string|int>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -150,7 +150,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<Token<string>> $expectedTokens
+     * @psalm-param list<Token<string, string|int>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -196,7 +196,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<Token<string>> $expectedTokens
+     * @psalm-param list<Token<string, string|int>> $expectedTokens
      *
      * @dataProvider dataProvider
      */
@@ -213,7 +213,7 @@ class AbstractLexerTest extends TestCase
     }
 
     /**
-     * @psalm-param list<Token<string>> $expectedTokens
+     * @psalm-param list<Token<string, string|int>> $expectedTokens
      *
      * @dataProvider dataProvider
      */

--- a/tests/ConcreteLexer.php
+++ b/tests/ConcreteLexer.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Lexer\AbstractLexer;
 use function in_array;
 use function is_numeric;
 
-/** @extends AbstractLexer<string> */
+/** @extends AbstractLexer<string, string|int> */
 class ConcreteLexer extends AbstractLexer
 {
     public const INT = 'int';

--- a/tests/EnumLexer.php
+++ b/tests/EnumLexer.php
@@ -9,7 +9,7 @@ use Doctrine\Common\Lexer\AbstractLexer;
 use function in_array;
 use function is_numeric;
 
-/** @extends AbstractLexer<TokenType> */
+/** @extends AbstractLexer<TokenType, string|int> */
 class EnumLexer extends AbstractLexer
 {
     /**

--- a/tests/MutableLexer.php
+++ b/tests/MutableLexer.php
@@ -6,7 +6,7 @@ namespace Doctrine\Tests\Common\Lexer;
 
 use Doctrine\Common\Lexer\AbstractLexer;
 
-/** @extends AbstractLexer<int> */
+/** @extends AbstractLexer<int, string> */
 class MutableLexer extends AbstractLexer
 {
     /** @var string[] */

--- a/tests/TokenTest.php
+++ b/tests/TokenTest.php
@@ -14,7 +14,7 @@ final class TokenTest extends TestCase
 
     public function testIsA(): void
     {
-        /** @var Token<'string'|'int'> $token */
+        /** @var Token<'string'|'int', string> $token */
         $token = new Token('foo', 'string', 1);
 
         self::assertTrue($token->isA('string'));


### PR DESCRIPTION
The ORM Lexer does not alter the type of token values in its `getType()` method. Having a way to restrict the type of token values to `string` should be very valuable from a static analysis point of view.