### PR TITLE
Use correct syntax for assertions

### DIFF
--- a/src/AbstractLexer.php
+++ b/src/AbstractLexer.php
@@ -148,7 +148,7 @@ abstract class AbstractLexer
      *
      * @return bool
      *
-     * @psalm-assert-if-true !null $this->lookahead
+     * @psalm-assert-if-true !=null $this->lookahead
      */
     public function isNextToken($type)
     {
@@ -162,7 +162,7 @@ abstract class AbstractLexer
      *
      * @return bool
      *
-     * @psalm-assert-if-true !null $this->lookahead
+     * @psalm-assert-if-true !=null $this->lookahead
      */
     public function isNextTokenAny(array $types)
     {
@@ -175,7 +175,6 @@ abstract class AbstractLexer
      * @return bool
      *
      * @psalm-assert-if-true !null $this->lookahead
-     * @psalm-assert-if-false null $this->lookahead
      */
     public function moveNext()
     {


### PR DESCRIPTION
The previous syntax resulted in assertions having an impact on both cases when true and false were returned.
Let us switch to equality assertions when we cannot deduce anything for the other case, and to a single assertion when we can deduce something in both cases.

See https://psalm.dev/docs/annotating_code/assertion_syntax/#equality-assertions 
See https://github.com/vimeo/psalm/issues/8896