### PR TITLE
Remove obsolete array types

### DIFF
--- a/src/AbstractLexer.php
+++ b/src/AbstractLexer.php
@@ -56,16 +56,14 @@ abstract class AbstractLexer
     /**
      * The next token in the input.
      *
-     * @var mixed[]|null
-     * @psalm-var Token<T, V>|null
+     * @var Token<T, V>|null
      */
     public $lookahead;
 
     /**
      * The last matched/seen token.
      *
-     * @var mixed[]|null
-     * @psalm-var Token<T, V>|null
+     * @var Token<T, V>|null
      */
     public $token;
 
@@ -217,8 +215,7 @@ abstract class AbstractLexer
     /**
      * Moves the lookahead token forward.
      *
-     * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token<T, V>|null
+     * @return Token<T, V>|null The next token or NULL if there are no more tokens ahead.
      */
     public function peek()
     {
@@ -232,8 +229,7 @@ abstract class AbstractLexer
     /**
      * Peeks at the next token, returns it and immediately resets the peek.
      *
-     * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
-     * @psalm-return Token<T, V>|null
+     * @return Token<T, V>|null The next token or NULL if there are no more tokens ahead.
      */
     public function glimpse()
     {


### PR DESCRIPTION
`AbstractLexer` still documents tokens as `mixed[]` sometimes which is a lie because we always get an instance of `Token` and never an array.