### PR TITLE
Mark some methods as as impure for PHPStan 

### DIFF
--- a/src/AbstractLexer.php
+++ b/src/AbstractLexer.php
@@ -164,6 +164,7 @@ abstract class AbstractLexer
      *
      * @return bool
      *
+     * @phpstan-impure
      * @psalm-assert-if-true !null $this->lookahead
      */
     public function moveNext()
@@ -220,6 +221,8 @@ abstract class AbstractLexer
      *
      * @return mixed[]|null The next token or NULL if there are no more tokens ahead.
      * @psalm-return Token<T, V>|null
+     *
+     * @phpstan-impure
      */
     public function glimpse()
     {


### PR DESCRIPTION
By default, PHPSTan considers assumes that all methods that return a
value are pure, meaning they have no side effects.

While we could configure PHPStan so it is consistent with Psalm, we do
not know how downstream projects are configured and should assume they
rely on the default behavior.

See https://phpstan.org/blog/remembering-and-forgetting-returned-values

Both `moveNext()` and `glimpse()` have side effects in that they modify
properties, and are therefore marked as impure.