### PR TITLE
fix bug Doctrine\\Common\\Lexer\\Token::__construct(): Argument #1 ($…

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -20,7 +20,7 @@ final class Token
      * @readonly
      * @var V
      */
-    public string|int $value;
+    public string|int|float $value;
 
     /**
      * The type of the token (identifier, numeric, string, input parameter, none)
@@ -41,7 +41,7 @@ final class Token
      * @param V      $value
      * @param T|null $type
      */
-    public function __construct(string|int $value, $type, int $position)
+    public function __construct(string|int|float $value, $type, int $position)
     {
         $this->value    = $value;
         $this->type     = $type;


### PR DESCRIPTION

fix bug Doctrine\\Common\\Lexer\\Token::__construct(): Argument #1 ($value) must be of type string|int, float given, called in vendor/doctrine/lexer/src/AbstractLexer.php on line 261 Token.php