### PR TITLE
Tell Psalm to use the lowest supported version

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <psalm
     errorLevel="1"
-    phpVersion="8.3"
+    phpVersion="8.1"
     resolveFromConfigFile="true"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns="https://getpsalm.org/schema/config"


### PR DESCRIPTION
Otherwise it is suggesting we do things that are not supported with PHP 8.1, like typing constants: https://php.watch/versions/8.3/typed-constants