### PR TITLE
Ignore MissingClassConstType

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -32,6 +32,7 @@
                 <file name="src/AbstractLexer.php" />
             </errorLevel>
         </InvalidReturnType>
+        <MissingClassConstType errorLevel="suppress" />
         <MixedAssignment>
             <errorLevel type="suppress">
                 <file name="src/AbstractLexer.php" />


### PR DESCRIPTION
It cannot be addressed until we drop support for PHP 8.2

Closes #122 