### PR TITLE
fix(doc): Typo in example CharacterTypeLexer pattern

### DIFF
--- a/docs/en/simple-parser-example.rst
+++ b/docs/en/simple-parser-example.rst
@@ -23,7 +23,7 @@ It tokenizes a string to ``T_UPPER``, ``T_LOWER`` and``T_NUMBER`` tokens:
         protected function getCatchablePatterns(): array
         {
             return [
-                '[a-bA-Z0-9]',
+                '[a-zA-Z0-9]',
             ];
         }
 


### PR DESCRIPTION
Maybe i didn't get it, but `a-z` seems the normal case for characters for me. Or maybe more generic with `\p{Alnum}`