### PR TITLE
fix: make resetPosition() accept a token character offset

### DIFF
--- a/src/AbstractLexer.php
+++ b/src/AbstractLexer.php
@@ -7,6 +7,7 @@ namespace Doctrine\Common\Lexer;
 use ReflectionClass;
 use UnitEnum;
 
+use function count;
 use function implode;
 use function preg_split;
 use function sprintf;
@@ -112,13 +113,31 @@ abstract class AbstractLexer
     /**
      * Resets the lexer position on the input to the given position.
      *
-     * @param int $position Position to place the lexical scanner.
+     * @param int $position Character offset into the input, as found in
+     *                      Token::$position; not an index in the token list.
      *
      * @return void
      */
     public function resetPosition(int $position = 0)
     {
-        $this->position = $position;
+        $this->position = $this->findTokenIndexAtOrAfterOffset($position);
+    }
+
+    /**
+     * Finds the index of the first token at or after the given offset.
+     *
+     * Token offsets are strictly increasing, so a linear scan suffices.
+     * Returns one past the end when there is no such token.
+     */
+    private function findTokenIndexAtOrAfterOffset(int $offset): int
+    {
+        foreach ($this->tokens as $index => $token) {
+            if ($token->position >= $offset) {
+                return $index;
+            }
+        }
+
+        return count($this->tokens);
     }
 
     /**

--- a/tests/AbstractLexerTest.php
+++ b/tests/AbstractLexerTest.php
@@ -86,6 +86,39 @@ class AbstractLexerTest extends TestCase
         $this->assertEquals($expectedTokens[0], $this->concreteLexer->lookahead);
     }
 
+    /**
+     * @see https://github.com/doctrine/lexer/issues/53
+     *
+     * resetPosition() takes a character offset, not a token index. The input
+     * below has multi-character tokens, so the second token's offset (6)
+     * differs from its index (1).
+     */
+    public function testResetPositionByTokenPosition(): void
+    {
+        $this->concreteLexer->setInput('price=10');
+
+        $this->assertTrue($this->concreteLexer->moveNext());
+        $this->assertTrue($this->concreteLexer->moveNext());
+
+        $target = $this->concreteLexer->lookahead;
+        $this->assertSame('=', $target->value);
+        $this->assertSame(5, $target->position);
+
+        // Move the cursor past the index that used to coincide with the target.
+        $remainingTokens = 0;
+        while ($this->concreteLexer->moveNext()) {
+            $remainingTokens++;
+        }
+
+        $this->assertSame(1, $remainingTokens);
+        $this->assertNull($this->concreteLexer->lookahead);
+
+        $this->concreteLexer->resetPosition($target->position);
+
+        $this->assertTrue($this->concreteLexer->moveNext());
+        $this->assertEquals($target, $this->concreteLexer->lookahead);
+    }
+
     /** @phpstan-param list<Token<string, string|int>>  $expectedTokens */
     #[DataProvider('dataProvider')]
     public function testMoveNext(string $input, array $expectedTokens): void


### PR DESCRIPTION

## Problem (doctrine/lexer#53)

https://github.com/doctrine/lexer/issues/53

`AbstractLexer::resetPosition($position)` is documented as resetting "the
lexer position on the input to the given position", and the only position
value the public API exposes to a consumer is `Token::$position` -- a
character offset into the input string (set from `preg_split()`'s
`PREG_SPLIT_OFFSET_CAPTURE` match offset in `scan()`).

Internally, however, `AbstractLexer::$position` is an index into the
`$tokens` array, not a character offset (`moveNext()` does
`$this->tokens[$this->position++]`). `resetPosition()` assigns its argument
straight into that internal index without any translation. For any lexer
whose tokens are not all exactly one character wide -- i.e. almost any real
grammar -- a token's array index and its character offset diverge, so
`resetPosition($token->position)` silently seeks to the wrong array slot (or
past the end of the array, in which case the lexer looks like it has no more
tokens at all).

## Root cause

`src/AbstractLexer.php`:
- `resetPosition()`, originally lines 119-122 (pre-fix): assigned the given
  `$position` verbatim to the internal `$this->position` array-index cursor.
- `moveNext()`, lines 170-178: consumes `$this->tokens[$this->position]` --
  confirming `$this->position` is an array index, not a character offset.
- `Token::$position` (`src/Token.php` line 38): the only position value
  exposed publicly, populated from the character offset produced by
  `preg_split(..., PREG_SPLIT_OFFSET_CAPTURE)` in `scan()`.

## Empirical reproduction (pre-fix)

Script: `repro_issue53.php` (untracked, kept locally as evidence, not part
of the commit). Lexer input `'hello world foo'` produces 3 tokens:
`'hello'` (array index 0, char offset 0), `'world'` (array index 1, char
offset 6), `'foo'` (array index 2, char offset 12).


`resetPosition(6)` set the internal array-index cursor to `6`, but the
token list only has 3 elements (indices 0-2), so `moveNext()` found nothing
and returned `null` instead of resuming at `'world'`.

## Fix

`resetPosition()` now resolves the given character offset to the correct
internal array index by scanning the token list for the first token whose
`Token::$position` is greater than or equal to the given offset (tokens are
produced by `scan()` in increasing offset order, so a single linear pass
suffices; no persistent offset-to-index map is kept, avoiding the extra
memory overhead the issue reporter was concerned about):

```php
public function resetPosition(int $position = 0)
{
    $this->position = $this->findTokenIndexAtOrAfterOffset($position);
}

private function findTokenIndexAtOrAfterOffset(int $offset): int
{
    foreach ($this->tokens as $index => $token) {
        if ($token->position >= $offset) {
            return $index;
        }
    }

    return count($this->tokens);
}
```

If no token starts at or after the given offset, the cursor is set one past
the end of the list, matching the "no more tokens" state produced by
naturally exhausting the lexer (same as what `moveNext()` already returns
in that situation).

## BC analysis

- `resetPosition(0)` (the default, and the only call already covered by the
  pre-existing test suite): unaffected. The first token in any non-empty
  token list always has offset >= 0, so the resolved array index is still
  0, exactly as before. For an empty token list both old and new code
  resolve to `0` / `count($tokens) === 0`.
- Lexers whose tokens are all exactly one character wide with no gaps
  (array index == character offset for every token): unaffected, old and
  new code resolve to the same array index for every token position.
- Lexers with multi-character tokens, called with a token's character
  offset (the only value the public API can produce): this is exactly the
  bug being fixed. The previous behavior was already broken for this case
  (wrong token, or `null`), so no currently-working caller can be relying
  on the old result.
- The parameter name/semantics are not being redefined in isolation:
  `getInputUntilPosition(int $position)` in the same class already treats
  `$position` as a character offset (`substr($this->input, 0, $position)`).
  The fix makes `resetPosition()` consistent with that existing sibling
  method and with `Token::$position`, rather than introducing a new
  contract.
- Residual risk: a caller that manually tracks the lexer's internal
  array-index cursor itself (e.g. counting its own `moveNext()` calls) and
  passes that raw counter to `resetPosition()` for a lexer with
  multi-character tokens would see a behavior change. This is not
  achievable through any documented/public API (the internal `$position`
  array index is private and never exposed), so no legitimate caller can
  depend on it without already re-implementing internal bookkeeping the
  library does not expose.
